### PR TITLE
Improve Aniworld UI integration and database recovery

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,11 +4,13 @@ from flask_socketio import SocketIO
 from datetime import datetime
 import os
 import json
-from scraper import StreamScraper
 import logging
 import threading
+import sqlite3
+import shutil
+from scraper import StreamScraper
 from config_manager import get_config
-from database import get_media_db
+from database import get_media_db, reset_media_db
 from gemini_client import GeminiClient
 
 # Get configuration
@@ -107,23 +109,29 @@ def gemini_settings():
 def search():
     query = request.args.get('q', '').strip()
     series_type = request.args.get('type', 'all')
+    include_all = request.args.get('all', 'false').lower() == 'true'
 
-    if not query:
+    base_query = Series.query
+    if series_type != 'all':
+        base_query = base_query.filter(Series.type == series_type)
+
+    if query:
+        like_query = f"%{query}%"
+        base_query = base_query.filter(Series.title.ilike(like_query))
+    elif not include_all:
         return jsonify([])
 
-    # Suche in der Datenbank
-    query = f"%{query}%"
-    if series_type == 'all':
-        results = Series.query.filter(Series.title.ilike(query)).all()
-    else:
-        results = Series.query.filter(Series.title.ilike(query), Series.type == series_type).all()
+    results = base_query.order_by(Series.title.asc()).limit(250).all()
 
-    return jsonify([{
-        'id': s.id,
-        'title': s.title,
-        'url': s.url,
-        'type': s.type
-    } for s in results])
+    return jsonify([
+        {
+            'id': s.id,
+            'title': s.title,
+            'url': s.url,
+            'type': s.type
+        }
+        for s in results
+    ])
 
 @app.route('/api/scrape/list', methods=['POST'])
 def scrape_list():
@@ -161,6 +169,44 @@ def scrape_list():
     except Exception as e:
         logger.error(f"Fehler beim Scraping: {str(e)}", exc_info=True)
         return jsonify({'error': str(e)}), 500
+
+
+@app.route('/api/db/repair', methods=['POST'])
+def repair_database():
+    """Prüft die SQLite-Datenbank und erstellt bei Bedarf eine neue Datei."""
+    db_path = config.get('download.db_path', 'media.db')
+
+    try:
+        if not os.path.exists(db_path):
+            message = f"Datenbank-Datei {db_path} wurde nicht gefunden."
+            logger.warning(message)
+            return jsonify({'status': 'missing', 'message': message}), 404
+
+        connection = sqlite3.connect(db_path)
+        result = connection.execute("PRAGMA integrity_check;").fetchone()
+        connection.close()
+
+        check_status = (result[0] if result else '').strip().lower()
+        if check_status == 'ok':
+            logger.info("Datenbank-Integritätsprüfung erfolgreich: ok")
+            return jsonify({'status': 'ok', 'message': 'Datenbank ist intakt.'})
+
+        timestamp = datetime.utcnow().strftime('%Y%m%d_%H%M%S')
+        backup_path = f"{db_path}.corrupt_{timestamp}.bak"
+        shutil.move(db_path, backup_path)
+        logger.warning("Datenbank war beschädigt. Backup gespeichert unter %s", backup_path)
+
+        global media_db
+        media_db = reset_media_db(db_path)
+
+        return jsonify({
+            'status': 'recreated',
+            'message': 'Beschädigte Datenbank wurde ersetzt. Bitte Verzeichnis erneut scannen.',
+            'backup': backup_path
+        })
+    except Exception as exc:
+        logger.error("Fehler bei der Datenbank-Reparatur: %s", exc, exc_info=True)
+        return jsonify({'status': 'error', 'error': str(exc)}), 500
 
 @app.route('/api/download', methods=['POST'])
 def start_download():

--- a/database.py
+++ b/database.py
@@ -733,3 +733,10 @@ def get_media_db(db_path: str = "media.db") -> MediaDatabase:
     if _media_db is None:
         _media_db = MediaDatabase(db_path)
     return _media_db
+
+
+def reset_media_db(db_path: str = "media.db") -> MediaDatabase:
+    """Erstelle die MediaDatabase neu und ersetze die Singleton-Instanz."""
+    global _media_db
+    _media_db = MediaDatabase(db_path)
+    return _media_db

--- a/scraper.py
+++ b/scraper.py
@@ -1145,43 +1145,86 @@ class StreamScraper:
         pass
 
     def get_anime_list(self) -> List[Dict[str, str]]:
-        """Scrape die Liste aller Animes von aniworld.to"""
-        url = "https://aniworld.to/animes"
+        """Scrape die Liste aller Animes von aniworld.to mit Retry-Logik."""
+        list_url = "https://aniworld.to/animes"
+        selectors = [
+            'ul li a[href^="/anime/stream/"]',
+            'a[href^="/anime/stream/"][title]',
+            '.seriesList a[href^="/anime/stream/"]',
+        ]
+        max_retries = 3
+        last_error: Optional[Exception] = None
 
-        try:
-            response = self.session.get(url, timeout=10)
-            response.raise_for_status()  # Wirft Fehler bei HTTP-Statuscode >= 400
+        for attempt in range(1, max_retries + 1):
+            try:
+                logging.debug(f"Hole Anime-Liste (Versuch {attempt}/{max_retries}) von {list_url}")
+                response = self.session.get(list_url, timeout=15)
+                response.raise_for_status()
 
-            soup = BeautifulSoup(response.text, 'html.parser')
-            anime_list = []
+                soup = BeautifulSoup(response.text, 'html.parser')
+                anime_list: List[Dict[str, Any]] = []
+                seen_urls: set[str] = set()
 
-            # Finde alle Anime-Links in allen Genre-Kategorien
-            for link in soup.select('ul li a[href^="/anime/stream/"]'):
-                title = link.text.strip()
-                if 'Stream anschauen' in title:
-                    title = title.replace(' Stream anschauen', '')
-                url = 'https://aniworld.to' + link.get('href', '')
+                for selector in selectors:
+                    for link in soup.select(selector):
+                        href = link.get('href', '').strip()
+                        if not href:
+                            continue
 
-                # Extrahiere alternative Titel falls vorhanden
-                alt_titles = []
-                if link.has_attr('data-alternative-title'):
-                    alt_titles = link.get('data-alternative-title', '').split(', ')
+                        full_url = urljoin("https://aniworld.to", href)
+                        if full_url in seen_urls:
+                            continue
 
-                if title and url:  # Nur hinzufügen wenn Titel und URL vorhanden
-                    # Prüfe ob der Anime bereits in der Liste ist (Duplikate vermeiden)
-                    if not any(anime['url'] == url for anime in anime_list):
+                        title = (
+                            link.get('title')
+                            or link.get('data-title')
+                            or link.get_text(strip=True)
+                            or ''
+                        ).strip()
+                        if not title:
+                            continue
+
+                        if 'Stream anschauen' in title:
+                            title = title.replace(' Stream anschauen', '').strip()
+
+                        alt_titles: List[str] = []
+                        alt_attr = link.get('data-alternative-title') or link.get('data-alt-titles')
+                        if alt_attr:
+                            alt_titles = [alt.strip() for alt in alt_attr.split(',') if alt.strip()]
+
                         anime_list.append({
                             'title': title,
-                            'url': url,
+                            'url': full_url,
                             'alternative_titles': alt_titles,
-                            'type': 'anime'
+                            'type': 'anime',
                         })
+                        seen_urls.add(full_url)
 
-            logging.info(f"Gefunden: {len(anime_list)} Animes")
-            return anime_list
-        except Exception as e:
-            logging.error(f"Fehler beim Scrapen der Anime-Liste: {str(e)}")
-            return []
+                if anime_list:
+                    logging.info(f"Gefunden: {len(anime_list)} Animes")
+                else:
+                    logging.warning("Keine Animes auf der Seite gefunden. Möglicherweise hat sich die Struktur geändert.")
+
+                return anime_list
+            except Exception as error:  # noqa: BLE001 - wir wollen alle Fehler loggen
+                last_error = error
+                logging.warning(
+                    "Fehler beim Laden der Anime-Liste (Versuch %s/%s): %s",
+                    attempt,
+                    max_retries,
+                    error,
+                )
+                if attempt < max_retries:
+                    delay = 1.5 * attempt
+                    logging.debug(f"Warte {delay:.1f}s vor erneutem Versuch...")
+                    time.sleep(delay)
+
+        logging.error(
+            "Fehler beim Scrapen der Anime-Liste nach %s Versuchen: %s",
+            max_retries,
+            last_error,
+        )
+        return []
 
     def get_series_list(self) -> List[Dict[str, str]]:
         """Scrape die Liste aller Serien von s.to"""

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -6,8 +6,8 @@ const searchInput = document.getElementById('search-input');
 const searchType = document.getElementById('search-type');
 const searchResults = document.getElementById('search-results');
 const updateDbBtn = document.getElementById('update-db-btn');
-const loadAnimeListBtn = document.getElementById('load-anime-list-btn');
-const animeListContainer = document.getElementById('anime-list');
+const loadAniworldBtn = document.getElementById('load-aniworld');
+const aniworldResults = document.getElementById('aniworld-results');
 const voeUrlInput = document.getElementById('voe-url');
 const voeFilenameInput = document.getElementById('voe-filename');
 const voeDownloadBtn = document.getElementById('voe-download-btn');
@@ -20,6 +20,7 @@ const downloadDirInput = document.getElementById('download-dir');
 const currentDownloadDir = document.getElementById('current-download-dir');
 const scanDirBtn = document.getElementById('scan-dir-btn');
 const clearDbBtn = document.getElementById('clear-db-btn');
+const repairDbBtn = document.getElementById('repair-db-btn');
 const dbStats = document.getElementById('db-stats');
 
 // Library elements
@@ -56,8 +57,8 @@ document.addEventListener('DOMContentLoaded', () => {
     updateDbBtn.addEventListener('click', updateDatabase);
 
     // Load Aniworld list
-    if (loadAnimeListBtn) {
-        loadAnimeListBtn.addEventListener('click', loadAniworldList);
+    if (loadAniworldBtn) {
+        loadAniworldBtn.addEventListener('click', loadAniworldList);
     }
 
     // VOE.sx download button
@@ -89,6 +90,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
     scanDirBtn.addEventListener('click', scanDirectory);
     clearDbBtn.addEventListener('click', clearDatabase);
+
+    if (repairDbBtn) {
+        repairDbBtn.addEventListener('click', repairDatabase);
+    }
 
     // Library event listeners
     librarySearch.addEventListener('input', handleLibrarySearch);
@@ -218,86 +223,153 @@ function updateDatabase() {
 }
 
 /**
- * Load Aniworld list via backend scrape
+ * Load Aniworld list via backend scrape and render results from the local database
  */
-function loadAniworldList() {
-    if (!loadAnimeListBtn || !animeListContainer) {
+async function loadAniworldList() {
+    if (!loadAniworldBtn || !aniworldResults) {
         return;
     }
 
-    const originalLabel = loadAnimeListBtn.innerHTML;
-    loadAnimeListBtn.disabled = true;
-    loadAnimeListBtn.innerHTML = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Laedt...';
+    const originalLabel = loadAniworldBtn.innerHTML;
+    loadAniworldBtn.disabled = true;
+    loadAniworldBtn.innerHTML = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Lädt...';
 
     showAniworldMessage('Lade Aniworld-Liste...', 'info');
 
-    fetch('/api/scrape/list', {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({ type: 'anime' })
-    })
-        .then(response => response.json())
-        .then(data => {
-            if (data.status === 'success' && Array.isArray(data.items)) {
-                renderAniworldList(data.items);
-            } else {
-                const message = typeof data.error === 'string' ? data.error : 'Unbekannter Fehler';
-                showAniworldMessage('Fehler beim Laden: ' + message, 'danger');
-            }
-        })
-        .catch(error => {
-            console.error('Error loading Aniworld list:', error);
-            showAniworldMessage('Fehler beim Laden der Aniworld-Liste', 'danger');
-        })
-        .finally(() => {
-            loadAnimeListBtn.disabled = false;
-            loadAnimeListBtn.innerHTML = originalLabel;
+    try {
+        const scrapeResponse = await fetch('/api/scrape/list', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({ type: 'anime' })
         });
+
+        const scrapeData = await scrapeResponse.json();
+        if (!scrapeResponse.ok) {
+            throw new Error(scrapeData?.error || scrapeResponse.statusText);
+        }
+
+        const scrapedItems = Array.isArray(scrapeData.items) ? scrapeData.items : [];
+
+        const params = new URLSearchParams({ type: 'anime', all: 'true' });
+        let databaseItems = [];
+        try {
+            const dbResponse = await fetch(`/search?${params.toString()}`);
+            if (dbResponse.ok) {
+                databaseItems = await dbResponse.json();
+            } else {
+                console.warn('Search request for Aniworld items failed with status', dbResponse.status);
+            }
+        } catch (err) {
+            console.warn('Search request for Aniworld items failed:', err);
+        }
+
+        const displayItems = Array.isArray(databaseItems) && databaseItems.length > 0
+            ? databaseItems
+            : scrapedItems;
+
+        renderAniworldList(displayItems, scrapeData.count || displayItems.length, scrapedItems);
+    } catch (error) {
+        console.error('Error loading Aniworld list:', error);
+        showAniworldMessage(`Fehler: ${error.message}`, 'danger');
+    } finally {
+        loadAniworldBtn.disabled = false;
+        loadAniworldBtn.innerHTML = originalLabel;
+    }
 }
 
 /**
  * Render Aniworld results
  */
-function renderAniworldList(items) {
-    if (!animeListContainer) {
+function renderAniworldList(items, scrapedCount = null, fallbackItems = []) {
+    if (!aniworldResults) {
         return;
     }
 
-    animeListContainer.innerHTML = '';
-    animeListContainer.classList.remove('d-none');
+    const initialItems = Array.isArray(items) ? items : [];
+    let displayItems = initialItems;
+    let usedFallback = false;
 
-    if (!Array.isArray(items) || items.length === 0) {
+    if (displayItems.length === 0 && Array.isArray(fallbackItems) && fallbackItems.length > 0) {
+        displayItems = fallbackItems;
+        usedFallback = true;
+    }
+
+    if (!Array.isArray(displayItems) || displayItems.length === 0) {
         showAniworldMessage('Keine Animes gefunden.', 'info');
         return;
     }
 
+    aniworldResults.innerHTML = '';
+    aniworldResults.classList.remove('d-none');
+
     const summary = document.createElement('div');
     summary.className = 'alert alert-secondary mb-2';
-    summary.textContent = items.length + ' Animes geladen';
-    animeListContainer.appendChild(summary);
+    const displayCount = displayItems.length;
+    const totalCount = typeof scrapedCount === 'number' ? scrapedCount : displayCount;
+    const infoText = totalCount !== displayCount
+        ? `${displayCount} von ${totalCount} Animes geladen`
+        : `${displayCount} Animes geladen`;
+
+    summary.textContent = usedFallback
+        ? `${infoText} (direkt aus Scrape)`
+        : infoText;
+
+    if (usedFallback) {
+        const hint = document.createElement('div');
+        hint.className = 'small text-muted mt-1';
+        hint.textContent = 'Hinweis: Die Einträge konnten nicht aus der lokalen Datenbank gelesen werden.';
+        summary.appendChild(hint);
+    }
+
+    aniworldResults.appendChild(summary);
 
     const listGroup = document.createElement('div');
     listGroup.className = 'list-group';
 
-    items.forEach((item) => {
-        const entry = document.createElement('a');
-        entry.href = '#';
-        entry.className = 'list-group-item list-group-item-action d-flex justify-content-between align-items-center';
+    displayItems.forEach((item) => {
+        const entry = document.createElement('div');
+        entry.className = 'list-group-item';
 
-        const titleWrapper = document.createElement('div');
+        const row = document.createElement('div');
+        row.className = 'row align-items-center g-2';
+        entry.appendChild(row);
+
+        const infoCol = document.createElement('div');
+        infoCol.className = 'col';
+
         const title = document.createElement('strong');
         title.textContent = item.title || 'Unbekannt';
-        titleWrapper.appendChild(title);
+        infoCol.appendChild(title);
 
         const badge = document.createElement('span');
         badge.className = 'badge bg-primary ms-2';
         badge.textContent = 'Anime';
-        titleWrapper.appendChild(badge);
+        infoCol.appendChild(badge);
+
+        const alternativeTitles = Array.isArray(item.alternative_titles)
+            ? item.alternative_titles
+            : Array.isArray(item.alt_titles)
+                ? item.alt_titles
+                : typeof item.alternative_titles === 'string'
+                    ? item.alternative_titles.split(',').map((alt) => alt.trim()).filter(Boolean)
+                    : [];
+
+        if (alternativeTitles.length > 0) {
+            const alt = document.createElement('div');
+            alt.className = 'small text-muted mt-1';
+            alt.textContent = alternativeTitles.join(' • ');
+            infoCol.appendChild(alt);
+        }
+
+        row.appendChild(infoCol);
+
+        const actionCol = document.createElement('div');
+        actionCol.className = 'col-auto';
 
         const downloadBtn = document.createElement('button');
-        downloadBtn.className = 'btn btn-sm btn-success download-btn';
+        downloadBtn.className = 'btn btn-sm btn-success';
         downloadBtn.textContent = 'Download';
 
         if (!item.url) {
@@ -308,33 +380,33 @@ function renderAniworldList(items) {
         } else {
             downloadBtn.addEventListener('click', (event) => {
                 event.preventDefault();
-                event.stopPropagation();
                 startDownload(item.url);
             });
         }
 
-        entry.appendChild(titleWrapper);
-        entry.appendChild(downloadBtn);
+        actionCol.appendChild(downloadBtn);
+        row.appendChild(actionCol);
+
         listGroup.appendChild(entry);
     });
 
-    animeListContainer.appendChild(listGroup);
+    aniworldResults.appendChild(listGroup);
 }
 
 /**
  * Show helper message inside Aniworld list container
  */
 function showAniworldMessage(message, level = 'info') {
-    if (!animeListContainer) {
+    if (!aniworldResults) {
         return;
     }
 
-    animeListContainer.innerHTML = '';
+    aniworldResults.innerHTML = '';
     const alert = document.createElement('div');
     alert.className = 'alert alert-' + level + ' mb-0';
     alert.textContent = message;
-    animeListContainer.appendChild(alert);
-    animeListContainer.classList.remove('d-none');
+    aniworldResults.appendChild(alert);
+    aniworldResults.classList.remove('d-none');
 }
 
 /**
@@ -622,6 +694,47 @@ function clearDatabase() {
         clearDbBtn.disabled = false;
         clearDbBtn.textContent = 'Datenbank zurücksetzen';
     });
+}
+
+/**
+ * Repair database by running integrity check and recreating if needed
+ */
+function repairDatabase() {
+    if (!repairDbBtn) {
+        return;
+    }
+
+    const originalLabel = repairDbBtn.innerHTML;
+    repairDbBtn.disabled = true;
+    repairDbBtn.innerHTML = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Prüfe...';
+
+    fetch('/api/db/repair', {
+        method: 'POST'
+    })
+        .then(async (response) => {
+            const data = await response.json().catch(() => ({}));
+            if (!response.ok) {
+                throw new Error(data.error || data.message || response.statusText);
+            }
+            return data;
+        })
+        .then((data) => {
+            const backupInfo = data.backup ? `\nBackup: ${data.backup}` : '';
+            const message = data.message || 'Datenbank wurde geprüft.';
+            alert(message + backupInfo);
+            loadDatabaseStats();
+            if (data.status === 'recreated') {
+                loadLibraryContent();
+            }
+        })
+        .catch((error) => {
+            console.error('Error repairing database:', error);
+            alert('Fehler bei der Datenbank-Prüfung: ' + error.message);
+        })
+        .finally(() => {
+            repairDbBtn.disabled = false;
+            repairDbBtn.innerHTML = originalLabel;
+        });
 }
 
 /**

--- a/templates/index.html
+++ b/templates/index.html
@@ -48,7 +48,7 @@
                     <div class="col-md-6">
                         <div class="d-flex gap-2 justify-content-md-end justify-content-start mt-2 mt-md-0">
                             <button id="update-db-btn" class="btn btn-primary">Datenbank aktualisieren</button>
-                            <button id="load-anime-list-btn" class="btn btn-secondary">Aniworld-Liste laden</button>
+                            <button id="load-aniworld" class="btn btn-secondary">Aniworld-Liste laden</button>
                         </div>
                     </div>
                 </div>
@@ -56,7 +56,7 @@
                 <div id="search-results" class="list-group mb-4">
                     <!-- Search results will be displayed here -->
                 </div>
-                <div id="anime-list" class="mb-4 d-none"></div>
+                <div id="aniworld-results" class="mb-4 d-none"></div>
             </div>
 
             <!-- Direct Download Tab -->
@@ -123,8 +123,11 @@
                     </div>
                     <div class="card-body">
                         <div class="mb-3">
-                            <button id="scan-dir-btn" class="btn btn-primary">Verzeichnis scannen</button>
-                            <button id="clear-db-btn" class="btn btn-danger ms-2">Datenbank zurücksetzen</button>
+                            <div class="btn-group" role="group">
+                                <button id="scan-dir-btn" class="btn btn-primary">Verzeichnis scannen</button>
+                                <button id="repair-db-btn" class="btn btn-warning">Datenbank prüfen</button>
+                                <button id="clear-db-btn" class="btn btn-danger">Datenbank zurücksetzen</button>
+                            </div>
                         </div>
                         <div id="db-stats" class="mt-3">
                             <h5>Statistiken</h5>


### PR DESCRIPTION
## Summary
- add a dedicated toolbar button and results container so the Aniworld catalogue can be rendered in the UI alongside a database repair control
- enhance the frontend workflow to trigger scraping, read back stored entries, render alternative titles, and expose a repair action
- expand the backend with a retrying Aniworld scraper, richer search API, and a database integrity endpoint including a reset helper

## Testing
- python -m compileall .
- pytest --maxfail=1 --disable-warnings -q *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68cc7b11f3c08331b790d12493656d5a