### PR TITLE
Adjust language verification fallbacks

### DIFF
--- a/config_manager.py
+++ b/config_manager.py
@@ -68,7 +68,7 @@ class ConfigManager:
             },
             "language": {
                 "prefer": ["de", "deu", "ger"],
-                "require_dub": True,
+                "require_dub": False,
                 "sample_seconds": 45,
                 "remux_to_de_if_present": True,
                 "accept_on_error": False,

--- a/config_manager.py
+++ b/config_manager.py
@@ -260,29 +260,30 @@ class ConfigManager:
             return False
 
     def get_language_priority(self) -> List[Tuple[Optional[str], Optional[str]]]:
-        """
-        Get the language priority configuration.
+        """Liefert die Sprach-Prioritäten als Liste von 2-Tupeln (audio_lang, dub_lang),
+        oder den Default, wenn nichts konfiguriert ist."""
+        try:
+            enabled = self.get("language_priority.enabled", True)
+            pr = self.get("language_priority.priorities", None)
+            if enabled and pr and all(isinstance(x, (list, tuple)) and len(x) == 2 for x in pr):
+                out: List[Tuple[Optional[str], Optional[str]]] = []
+                for a, d in pr:
+                    audio = str(a).lower() if a is not None else None
+                    dub = str(d).lower() if d is not None else None
+                    out.append((audio, dub))
+                return out
+        except Exception:
+            pass
 
-        Returns:
-            List[Tuple[Optional[str], Optional[str]]]: List of (audio_lang, dub_lang) tuples
-        """
-        if not self.config.get('language_priority', {}).get('enabled', True):
-            return []
-
-        priorities = self.config.get('language_priority', {}).get('priorities', [])
-        if not priorities:
-            # Fallback to default priorities
-            return [
-                ("de", None),     # Deutsch
-                ("en", "de"),     # Englisch mit German Dub
-                ("en", None),     # Englisch
-                ("ja", "de"),     # Japanisch mit German Dub
-                ("ja", "en"),     # Japanisch mit English Dub
-                ("ja", None)      # Japanisch (Original)
-            ]
-
-        # Convert list of lists to list of tuples
-        return [(audio, dub) for audio, dub in priorities]
+        # Fallback entspricht deinem Default
+        return [
+            ("de", None),
+            ("en", "de"),
+            ("en", None),
+            ("ja", "de"),
+            ("ja", "en"),
+            ("ja", None),
+        ]
 
 
 # Singleton instance

--- a/config_manager.py
+++ b/config_manager.py
@@ -6,7 +6,7 @@ Combines settings from .env, config.json, and environment variables.
 import os
 import json
 import logging
-from typing import Dict, Any, Optional, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 from dotenv import load_dotenv
 
 # Configure logging

--- a/language_guard.py
+++ b/language_guard.py
@@ -432,6 +432,9 @@ LANG_MAP = {
     "zh": [r"\bzh\b", r"chinese", r"chinesisch", r"chi\b", r"中文", r"🇨🇳", r"flag.*zh"],
 }
 
+# Entferne leere Regex-Einträge, damit keine Sprache versehentlich alles matched.
+LANG_MAP = {lang: [pattern for pattern in patterns if pattern] for lang, patterns in LANG_MAP.items()}
+
 DUB_PATTERNS = {
     "de": [
         r"german\s*dub", r"ger\s*dub", r"de\s*dub", r"deutsch(?:e|er)?\s*dub",

--- a/language_guard.py
+++ b/language_guard.py
@@ -439,26 +439,26 @@ DUB_PATTERNS = {
     "de": [
         r"german\s*dub", r"ger\s*dub", r"de\s*dub", r"deutsch(?:e|er)?\s*dub",
         r"gerdub", r"ger-dub", r"de-dub", r"deutsch.*dub", r"german.*dub",
-        r"dubbed.*german", r"dubbed.*deutsch", r"dub.*ger", r"dub.*de",
+        r"dubbed.*german", r"dubbed.*deutsch",
         r"🇩🇪.*dub", r"flag.*de.*dub"
     ],
     "en": [
         r"english\s*dub", r"eng\s*dub", r"en\s*dub", r"english.*dub", r"eng.*dub",
-        r"dubbed.*english", r"dubbed.*eng", r"dub.*en", r"dub.*english",
+        r"dubbed.*english", r"dubbed.*eng",
         r"🇺🇸.*dub", r"flag.*en.*dub"
     ],
     "ja": [
         r"japanese\s*dub", r"jap\s*dub", r"ja\s*dub", r"japanese.*dub", r"jap.*dub",
-        r"dubbed.*japanese", r"dubbed.*jap", r"dub.*ja", r"dub.*japanese",
+        r"dubbed.*japanese", r"dubbed.*jap",
         r"🇯🇵.*dub", r"flag.*jp.*dub"
     ],
-    "fr": [r"french\s*dub", r"fra\s*dub", r"fr\s*dub", r"french.*dub", r"dub.*french"],
-    "es": [r"spanish\s*dub", r"spa\s*dub", r"es\s*dub", r"spanish.*dub", r"dub.*spanish"],
-    "it": [r"italian\s*dub", r"ita\s*dub", r"it\s*dub", r"italian.*dub", r"dub.*italian"],
-    "pt": [r"portuguese\s*dub", r"por\s*dub", r"pt\s*dub", r"portuguese.*dub", r"dub.*portuguese"],
-    "ru": [r"russian\s*dub", r"rus\s*dub", r"ru\s*dub", r"russian.*dub", r"dub.*russian"],
-    "ko": [r"korean\s*dub", r"kor\s*dub", r"ko\s*dub", r"korean.*dub", r"dub.*korean"],
-    "zh": [r"chinese\s*dub", r"chi\s*dub", r"zh\s*dub", r"chinese.*dub", r"dub.*chinese"],
+    "fr": [r"french\s*dub", r"fra\s*dub", r"fr\s*dub", r"french.*dub"],
+    "es": [r"spanish\s*dub", r"spa\s*dub", r"es\s*dub", r"spanish.*dub"],
+    "it": [r"italian\s*dub", r"ita\s*dub", r"it\s*dub", r"italian.*dub"],
+    "pt": [r"portuguese\s*dub", r"por\s*dub", r"pt\s*dub", r"portuguese.*dub"],
+    "ru": [r"russian\s*dub", r"rus\s*dub", r"ru\s*dub", r"russian.*dub"],
+    "ko": [r"korean\s*dub", r"kor\s*dub", r"ko\s*dub", r"korean.*dub"],
+    "zh": [r"chinese\s*dub", r"chi\s*dub", r"zh\s*dub", r"chinese.*dub"],
 }
 
 # Additional patterns for special cases

--- a/language_guard.py
+++ b/language_guard.py
@@ -296,7 +296,7 @@ def audit_and_retry(download_func, candidate_urls: list[str]) -> tuple[str | Non
             print(f"Download failed for {url}: {e}")
             continue
     
-    return None, "no-valid-de-source"
+    return None, "no-valid-source-any-lang"
 
 
 
@@ -438,27 +438,27 @@ LANG_MAP = {lang: [pattern for pattern in patterns if pattern] for lang, pattern
 DUB_PATTERNS = {
     "de": [
         r"german\s*dub", r"ger\s*dub", r"de\s*dub", r"deutsch(?:e|er)?\s*dub",
-        r"gerdub", r"ger-dub", r"de-dub", r"deutsch.*dub", r"german.*dub",
-        r"dubbed.*german", r"dubbed.*deutsch",
+        r"gerdub", r"ger-dub", r"de-dub",
+        r"(?:deutsch|german).*dub", r"dub(?:bed)?\s*(?:deutsch|german|ger|de)\b",
         r"🇩🇪.*dub", r"flag.*de.*dub"
     ],
     "en": [
-        r"english\s*dub", r"eng\s*dub", r"en\s*dub", r"english.*dub", r"eng.*dub",
-        r"dubbed.*english", r"dubbed.*eng",
+        r"english\s*dub", r"eng\s*dub", r"en\s*dub",
+        r"(?:english|eng|en).*dub", r"dub(?:bed)?\s*(?:english|eng|en)\b",
         r"🇺🇸.*dub", r"flag.*en.*dub"
     ],
     "ja": [
-        r"japanese\s*dub", r"jap\s*dub", r"ja\s*dub", r"japanese.*dub", r"jap.*dub",
-        r"dubbed.*japanese", r"dubbed.*jap",
+        r"japanese\s*dub", r"jap\s*dub", r"ja\s*dub",
+        r"(?:japanese|jap|ja).*dub", r"dub(?:bed)?\s*(?:japanese|jap|ja)\b",
         r"🇯🇵.*dub", r"flag.*jp.*dub"
     ],
-    "fr": [r"french\s*dub", r"fra\s*dub", r"fr\s*dub", r"french.*dub"],
-    "es": [r"spanish\s*dub", r"spa\s*dub", r"es\s*dub", r"spanish.*dub"],
-    "it": [r"italian\s*dub", r"ita\s*dub", r"it\s*dub", r"italian.*dub"],
-    "pt": [r"portuguese\s*dub", r"por\s*dub", r"pt\s*dub", r"portuguese.*dub"],
-    "ru": [r"russian\s*dub", r"rus\s*dub", r"ru\s*dub", r"russian.*dub"],
-    "ko": [r"korean\s*dub", r"kor\s*dub", r"ko\s*dub", r"korean.*dub"],
-    "zh": [r"chinese\s*dub", r"chi\s*dub", r"zh\s*dub", r"chinese.*dub"],
+    "fr": [r"french\s*dub", r"fra\s*dub", r"fr\s*dub", r"(?:french|fra|fr).*dub"],
+    "es": [r"spanish\s*dub", r"spa\s*dub", r"es\s*dub", r"(?:spanish|spa|es).*dub"],
+    "it": [r"italian\s*dub", r"ita\s*dub", r"it\s*dub", r"(?:italian|ita|it).*dub"],
+    "pt": [r"portuguese\s*dub", r"por\s*dub", r"pt\s*dub", r"(?:portuguese|por|pt).*dub"],
+    "ru": [r"russian\s*dub", r"rus\s*dub", r"ru\s*dub", r"(?:russian|rus|ru).*dub"],
+    "ko": [r"korean\s*dub", r"kor\s*dub", r"ko\s*dub", r"(?:korean|kor|ko).*dub"],
+    "zh": [r"chinese\s*dub", r"chi\s*dub", r"zh\s*dub", r"(?:chinese|chi|zh).*dub"],
 }
 
 # Additional patterns for special cases


### PR DESCRIPTION
## Summary
- extend `verify_language` with target-aware whisper acceptance, improved remux handling, and subs-only/dub-required logic
- add a prioritized audit helper with clearer logging and update configuration defaults to allow non-dub fallbacks

## Testing
- pytest *(fails: missing optional dependency `requests` and duplicate test module name)*

------
https://chatgpt.com/codex/tasks/task_e_68d2f0acde088331a870646086c7781a