### PR TITLE
Harden library config usage and database paths

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,20 +6,34 @@
         "scan_on_startup": true,
         "db_path": "media.db"
     },
+    "libraries": [
+        {
+            "id": 1,
+            "name": "Serien",
+            "path": "D:\\Serien",
+            "is_default": true
+        },
+        {
+            "id": 2,
+            "name": "Animes",
+            "path": "D:\\Animes",
+            "is_default": false
+        }
+    ],
     "server": {
         "port": 5000,
         "debug": true,
         "host": "127.0.0.1"
     },
     "real_debrid": {
-        "enabled": true,
-        "api_key": "3MPG4CODV34NE3TQOSLN2ZF6Y4YCPTPQJLLEYW3JVATBW7TWU3PQ"
+        "enabled": false,
+        "api_key": ""
     },
     "jellyfin": {
-        "enabled": true,
+        "enabled": false,
         "url": "http://localhost:8096/",
-        "api_key": "bb7a4258f47b40dca98033d6edb97000",
-        "user_id": "Xhafer"
+        "api_key": "",
+        "user_id": ""
     },
     "logging": {
         "level": "DEBUG",
@@ -27,8 +41,8 @@
     },
     "gemini": {
         "enabled": false,
-        "api_key": "AIzaSyAj5-0iw3fwz08ffikbR3DcqkheczFO0Z0",
-        "model": "gemini-2.5-pro-exp-03-25",
+        "api_key": "",
+        "model": "gemini-1.5-pro-latest",
         "auto_enhance_metadata": false
     },
     "language": {
@@ -46,6 +60,35 @@
             "de",
             "en",
             "ja"
+        ]
+    },
+    "language_priority": {
+        "enabled": true,
+        "priorities": [
+            [
+                "de",
+                null
+            ],
+            [
+                "en",
+                "de"
+            ],
+            [
+                "ja",
+                "de"
+            ],
+            [
+                "ja",
+                "en"
+            ],
+            [
+                "ja",
+                null
+            ],
+            [
+                "en",
+                null
+            ]
         ]
     },
     "scraper": {

--- a/templates/index.html
+++ b/templates/index.html
@@ -136,6 +136,35 @@
 
             <!-- Library Tab -->
             <div class="tab-pane fade" id="library" role="tabpanel" aria-labelledby="library-tab">
+                <div class="card mb-4">
+                    <div class="card-header">
+                        Bibliotheken verwalten
+                    </div>
+                    <div class="card-body">
+                        <form id="library-form" class="row g-3">
+                            <div class="col-md-4">
+                                <label for="library-name" class="form-label">Name</label>
+                                <input type="text" id="library-name" class="form-control" placeholder="Anime Bibliothek" required>
+                            </div>
+                            <div class="col-md-6">
+                                <label for="library-path" class="form-label">Pfad</label>
+                                <input type="text" id="library-path" class="form-control" placeholder="D:\\Medien\\Animes" required>
+                            </div>
+                            <div class="col-md-2 align-self-end">
+                                <div class="form-check mt-4">
+                                    <input class="form-check-input" type="checkbox" id="library-default">
+                                    <label class="form-check-label" for="library-default">Standard</label>
+                                </div>
+                            </div>
+                            <div class="col-12 text-end">
+                                <button type="submit" class="btn btn-primary">Bibliothek hinzufügen</button>
+                            </div>
+                        </form>
+                        <div id="libraries-list" class="mt-4">
+                            <div class="text-muted">Noch keine Bibliotheken geladen.</div>
+                        </div>
+                    </div>
+                </div>
                 <div class="row mb-3">
                     <div class="col-md-6">
                         <div class="input-group">


### PR DESCRIPTION
## Summary
- introduce SQLAlchemy models and helpers to sync libraries from config, along with CRUD and assignment API routes
- resolve download targets based on assigned or default libraries and pass the path override through to the scraper
- expose library management in the UI and JavaScript, and extend configuration defaults/config.json with sample libraries
- harden configuration defaults by stripping secrets, loading env overrides, and providing the updated language priority fallback order
- resolve the SQLite database path using an absolute location and guard Real-Debrid when the API key is missing

## Testing
- pytest *(fails: missing third-party dependency `requests`)*
- pip install requests *(fails: proxy blocks access to the package index)*

------
https://chatgpt.com/codex/tasks/task_e_68d335f06f9083319e8d84aa84f6e051