### PR TITLE
Embed global download status bar

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -30,11 +30,63 @@
     transition: width 0.3s ease;
 }
 
-#cancel-download-btn {
+.global-download {
+    background-color: #212529;
+    color: #fff;
+    padding: 0.75rem 1rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+}
+
+.global-download.hidden {
     display: none;
 }
 
-/* Show cancel button when download is active */
-.downloading #cancel-download-btn {
+.global-download__info {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    min-width: 180px;
+}
+
+.global-download__progress {
+    flex: 1 1 200px;
+    background-color: #343a40;
+    border-radius: 4px;
+    overflow: hidden;
+    height: 20px;
+    position: relative;
+}
+
+.global-download__progress > #statusProgress {
+    background-color: #0d6efd;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 600;
+    transition: width 0.3s ease;
+}
+
+.global-download__meta {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+#cancelDownloadBtn {
+    display: none;
+    border: none;
+    background-color: #dc3545;
+    color: #fff;
+    padding: 0.35rem 0.75rem;
+    border-radius: 4px;
+}
+
+.downloading #cancelDownloadBtn {
     display: inline-block;
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -10,6 +10,19 @@
     {% block head %}{% endblock %}
 </head>
 <body>
+    <div id="downloadStatus" class="global-download hidden">
+        <div class="global-download__info">
+            <strong id="statusTitle">Kein aktiver Download</strong>
+            <span id="statusMessage">-</span>
+        </div>
+        <div class="global-download__progress">
+            <div id="statusProgress" style="width: 0%;">0%</div>
+        </div>
+        <div class="global-download__meta">
+            <span>Episoden: <span id="statusEpisode">-</span>/<span id="statusTotalEpisodes">-</span></span>
+            <button id="cancelDownloadBtn" type="button" style="display: none;">Abbrechen</button>
+        </div>
+    </div>
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
         <div class="container-fluid">
             <a class="navbar-brand" href="/">Stream Scraper</a>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,198 +1,185 @@
-<!DOCTYPE html>
-<html lang="de">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Stream Scraper</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
-</head>
-<body>
-    <div class="container mt-4">
-        <h1 class="mb-4">Stream Scraper</h1>
+{% extends 'base.html' %}
 
-        <!-- Tabs -->
-        <ul class="nav nav-tabs mb-4" id="myTab" role="tablist">
-            <li class="nav-item" role="presentation">
-                <button class="nav-link active" id="search-tab" data-bs-toggle="tab" data-bs-target="#search" type="button" role="tab" aria-controls="search" aria-selected="true">Suche</button>
-            </li>
-            <li class="nav-item" role="presentation">
-                <button class="nav-link" id="direct-tab" data-bs-toggle="tab" data-bs-target="#direct" type="button" role="tab" aria-controls="direct" aria-selected="false">Direkter Download</button>
-            </li>
-            <li class="nav-item" role="presentation">
-                <button class="nav-link" id="status-tab" data-bs-toggle="tab" data-bs-target="#status" type="button" role="tab" aria-controls="status" aria-selected="false">Status</button>
-            </li>
-            <li class="nav-item" role="presentation">
-                <button class="nav-link" id="settings-tab" data-bs-toggle="tab" data-bs-target="#settings" type="button" role="tab" aria-controls="settings" aria-selected="false">Einstellungen</button>
-            </li>
-            <li class="nav-item" role="presentation">
-                <button class="nav-link" id="library-tab" data-bs-toggle="tab" data-bs-target="#library" type="button" role="tab" aria-controls="library" aria-selected="false">Mediathek</button>
-            </li>
-        </ul>
+{% block title %}Stream Scraper{% endblock %}
 
-        <!-- Tab Content -->
-        <div class="tab-content" id="myTabContent">
-            <!-- Search Tab -->
-            <div class="tab-pane fade show active" id="search" role="tabpanel" aria-labelledby="search-tab">
-                <div class="row mb-3">
-                    <div class="col-md-6">
-                        <div class="input-group">
-                            <input type="text" id="search-input" class="form-control" placeholder="Suche nach Serien oder Animes...">
-                            <select id="search-type" class="form-select" style="max-width: 120px;">
-                                <option value="all">Alle</option>
-                                <option value="series">Serien</option>
-                                <option value="anime">Animes</option>
-                            </select>
-                        </div>
-                    </div>
-                    <div class="col-md-6">
-                        <div class="d-flex gap-2 justify-content-md-end justify-content-start mt-2 mt-md-0">
-                            <button id="update-db-btn" class="btn btn-primary">Datenbank aktualisieren</button>
-                            <button id="load-anime-list-btn" class="btn btn-secondary">Aniworld-Liste laden</button>
-                        </div>
+{% block content %}
+<div class="container mt-4">
+    <h1 class="mb-4">Stream Scraper</h1>
+
+    <!-- Tabs -->
+    <ul class="nav nav-tabs mb-4" id="myTab" role="tablist">
+        <li class="nav-item" role="presentation">
+            <button class="nav-link active" id="search-tab" data-bs-toggle="tab" data-bs-target="#search" type="button" role="tab" aria-controls="search" aria-selected="true">Suche</button>
+        </li>
+        <li class="nav-item" role="presentation">
+            <button class="nav-link" id="direct-tab" data-bs-toggle="tab" data-bs-target="#direct" type="button" role="tab" aria-controls="direct" aria-selected="false">Direkter Download</button>
+        </li>
+        <li class="nav-item" role="presentation">
+            <button class="nav-link" id="status-tab" data-bs-toggle="tab" data-bs-target="#status" type="button" role="tab" aria-controls="status" aria-selected="false">Status</button>
+        </li>
+        <li class="nav-item" role="presentation">
+            <button class="nav-link" id="settings-tab" data-bs-toggle="tab" data-bs-target="#settings" type="button" role="tab" aria-controls="settings" aria-selected="false">Einstellungen</button>
+        </li>
+        <li class="nav-item" role="presentation">
+            <button class="nav-link" id="library-tab" data-bs-toggle="tab" data-bs-target="#library" type="button" role="tab" aria-controls="library" aria-selected="false">Mediathek</button>
+        </li>
+    </ul>
+
+    <!-- Tab Content -->
+    <div class="tab-content" id="myTabContent">
+        <!-- Search Tab -->
+        <div class="tab-pane fade show active" id="search" role="tabpanel" aria-labelledby="search-tab">
+            <div class="row mb-3">
+                <div class="col-md-6">
+                    <div class="input-group">
+                        <input type="text" id="search-input" class="form-control" placeholder="Suche nach Serien oder Animes...">
+                        <select id="search-type" class="form-select" style="max-width: 120px;">
+                            <option value="all">Alle</option>
+                            <option value="series">Serien</option>
+                            <option value="anime">Animes</option>
+                        </select>
                     </div>
                 </div>
-
-                <div id="search-results" class="list-group mb-4">
-                    <!-- Search results will be displayed here -->
-                </div>
-                <div id="anime-list" class="mb-4 d-none"></div>
-            </div>
-
-            <!-- Direct Download Tab -->
-            <div class="tab-pane fade" id="direct" role="tabpanel" aria-labelledby="direct-tab">
-                <div class="mb-3">
-                    <label for="voe-url" class="form-label">VOE.sx URL</label>
-                    <input type="text" class="form-control" id="voe-url" placeholder="https://voe.sx/e/...">
-                </div>
-                <div class="mb-3">
-                    <label for="voe-filename" class="form-label">Dateiname (optional)</label>
-                    <input type="text" class="form-control" id="voe-filename" placeholder="video.mp4">
-                </div>
-                <button id="voe-download-btn" class="btn btn-primary">Download starten</button>
-            </div>
-
-            <!-- Status Tab -->
-            <div class="tab-pane fade" id="status" role="tabpanel" aria-labelledby="status-tab">
-                <div id="download-status" class="card mb-4">
-                    <div class="card-header">
-                        Download Status
-                    </div>
-                    <div class="card-body">
-                        <h5 class="card-title" id="status-title">Kein aktiver Download</h5>
-                        <p class="card-text" id="status-message">-</p>
-                        <div class="progress mb-3" style="display: none;">
-                            <div id="status-progress" class="progress-bar" role="progressbar" style="width: 0%;" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">0%</div>
-                        </div>
-                        <p class="card-text">
-                            <small class="text-muted">
-                                Episode: <span id="status-episode">-</span> / <span id="status-total-episodes">-</span>
-                            </small>
-                        </p>
-                        <div class="d-flex justify-content-between">
-                            <button id="reset-session-btn" class="btn btn-secondary">Session zurücksetzen</button>
-                            <button id="cancel-download-btn" class="btn btn-danger">Download abbrechen</button>
-                        </div>
+                <div class="col-md-6">
+                    <div class="d-flex gap-2 justify-content-md-end justify-content-start mt-2 mt-md-0">
+                        <button id="update-db-btn" class="btn btn-primary">Datenbank aktualisieren</button>
+                        <button id="load-anime-list-btn" class="btn btn-secondary">Aniworld-Liste laden</button>
                     </div>
                 </div>
             </div>
 
-            <!-- Settings Tab -->
-            <div class="tab-pane fade" id="settings" role="tabpanel" aria-labelledby="settings-tab">
-                <div class="card mb-4">
-                    <div class="card-header">
-                        Download-Einstellungen
-                    </div>
-                    <div class="card-body">
-                        <form id="download-dir-form">
-                            <div class="mb-3">
-                                <label for="download-dir" class="form-label">Download-Verzeichnis</label>
-                                <div class="input-group">
-                                    <input type="text" class="form-control" id="download-dir" placeholder="C:\Downloads">
-                                    <button class="btn btn-primary" type="submit">Speichern</button>
-                                </div>
-                                <div class="form-text">Aktuelles Verzeichnis: <span id="current-download-dir">...</span></div>
-                            </div>
-                        </form>
-                    </div>
-                </div>
-
-                <div class="card mb-4">
-                    <div class="card-header">
-                        Datenbank-Verwaltung
-                    </div>
-                    <div class="card-body">
-                        <div class="mb-3">
-                            <button id="scan-dir-btn" class="btn btn-primary">Verzeichnis scannen</button>
-                            <button id="clear-db-btn" class="btn btn-danger ms-2">Datenbank zurücksetzen</button>
-                        </div>
-                        <div id="db-stats" class="mt-3">
-                            <h5>Statistiken</h5>
-                            <p>Lade Statistiken...</p>
-                        </div>
-                    </div>
-                </div>
+            <div id="search-results" class="list-group mb-4">
+                <!-- Search results will be displayed here -->
             </div>
+            <div id="anime-list" class="mb-4 d-none"></div>
+        </div>
 
-            <!-- Library Tab -->
-            <div class="tab-pane fade" id="library" role="tabpanel" aria-labelledby="library-tab">
-                <div class="card mb-4">
-                    <div class="card-header">
-                        Bibliotheken verwalten
-                    </div>
-                    <div class="card-body">
-                        <form id="library-form" class="row g-3">
-                            <div class="col-md-4">
-                                <label for="library-name" class="form-label">Name</label>
-                                <input type="text" id="library-name" class="form-control" placeholder="Anime Bibliothek" required>
-                            </div>
-                            <div class="col-md-6">
-                                <label for="library-path" class="form-label">Pfad</label>
-                                <input type="text" id="library-path" class="form-control" placeholder="D:\\Medien\\Animes" required>
-                            </div>
-                            <div class="col-md-2 align-self-end">
-                                <div class="form-check mt-4">
-                                    <input class="form-check-input" type="checkbox" id="library-default">
-                                    <label class="form-check-label" for="library-default">Standard</label>
-                                </div>
-                            </div>
-                            <div class="col-12 text-end">
-                                <button type="submit" class="btn btn-primary">Bibliothek hinzufügen</button>
-                            </div>
-                        </form>
-                        <div id="libraries-list" class="mt-4">
-                            <div class="text-muted">Noch keine Bibliotheken geladen.</div>
-                        </div>
-                    </div>
-                </div>
-                <div class="row mb-3">
-                    <div class="col-md-6">
-                        <div class="input-group">
-                            <input type="text" id="library-search" class="form-control" placeholder="In Mediathek suchen...">
-                            <select id="library-type" class="form-select" style="max-width: 120px;">
-                                <option value="all">Alle</option>
-                                <option value="series">Serien</option>
-                                <option value="anime">Animes</option>
-                            </select>
-                        </div>
-                    </div>
-                    <div class="col-md-6 text-end">
-                        <button id="refresh-library-btn" class="btn btn-primary">Aktualisieren</button>
-                    </div>
-                </div>
+        <!-- Direct Download Tab -->
+        <div class="tab-pane fade" id="direct" role="tabpanel" aria-labelledby="direct-tab">
+            <div class="mb-3">
+                <label for="voe-url" class="form-label">VOE.sx URL</label>
+                <input type="text" class="form-control" id="voe-url" placeholder="https://voe.sx/e/...">
+            </div>
+            <div class="mb-3">
+                <label for="voe-filename" class="form-label">Dateiname (optional)</label>
+                <input type="text" class="form-control" id="voe-filename" placeholder="video.mp4">
+            </div>
+            <button id="voe-download-btn" class="btn btn-primary">Download starten</button>
+        </div>
 
-                <div id="library-content">
-                    <div class="alert alert-info">Lade Mediathek...</div>
+        <!-- Status Tab -->
+        <div class="tab-pane fade" id="status" role="tabpanel" aria-labelledby="status-tab">
+            <div id="download-status-card" class="card mb-4">
+                <div class="card-header">
+                    Download Status
+                </div>
+                <div class="card-body">
+                    <h5 class="card-title" id="status-card-title">Kein aktiver Download</h5>
+                    <p class="card-text" id="status-card-message">-</p>
+                    <div class="progress mb-3" id="status-card-progress-wrapper" style="display: none;">
+                        <div id="status-card-progress" class="progress-bar" role="progressbar" style="width: 0%;" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">0%</div>
+                    </div>
+                    <p class="card-text">
+                        <small class="text-muted">
+                            Episode: <span id="status-card-episode">-</span> / <span id="status-card-total-episodes">-</span>
+                        </small>
+                    </p>
+                    <div class="d-flex justify-content-between">
+                        <button id="reset-session-btn" class="btn btn-secondary">Session zurücksetzen</button>
+                        <button id="cancel-download-btn" class="btn btn-danger" style="display: none;">Download abbrechen</button>
+                    </div>
                 </div>
             </div>
         </div>
-    </div>
 
-    <!-- Socket.IO -->
-    <script src="https://cdn.socket.io/4.4.1/socket.io.min.js"></script>
-    <!-- Bootstrap JS -->
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    <!-- Custom JS -->
-    <script src="{{ url_for('static', filename='js/main.js') }}"></script>
-</body>
-</html>
+        <!-- Settings Tab -->
+        <div class="tab-pane fade" id="settings" role="tabpanel" aria-labelledby="settings-tab">
+            <div class="card mb-4">
+                <div class="card-header">
+                    Download-Einstellungen
+                </div>
+                <div class="card-body">
+                    <form id="download-dir-form">
+                        <div class="mb-3">
+                            <label for="download-dir" class="form-label">Download-Verzeichnis</label>
+                            <div class="input-group">
+                                <input type="text" class="form-control" id="download-dir" placeholder="C:\\Downloads">
+                                <button class="btn btn-primary" type="submit">Speichern</button>
+                            </div>
+                            <div class="form-text">Aktuelles Verzeichnis: <span id="current-download-dir">...</span></div>
+                        </div>
+                    </form>
+                </div>
+            </div>
+
+            <div class="card mb-4">
+                <div class="card-header">
+                    Datenbank-Verwaltung
+                </div>
+                <div class="card-body">
+                    <div class="mb-3">
+                        <button id="scan-dir-btn" class="btn btn-primary">Verzeichnis scannen</button>
+                        <button id="clear-db-btn" class="btn btn-danger ms-2">Datenbank zurücksetzen</button>
+                    </div>
+                    <div id="db-stats" class="mt-3">
+                        <h5>Statistiken</h5>
+                        <p>Lade Statistiken...</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Library Tab -->
+        <div class="tab-pane fade" id="library" role="tabpanel" aria-labelledby="library-tab">
+            <div class="card mb-4">
+                <div class="card-header">
+                    Bibliotheken verwalten
+                </div>
+                <div class="card-body">
+                    <form id="library-form" class="row g-3">
+                        <div class="col-md-4">
+                            <label for="library-name" class="form-label">Name</label>
+                            <input type="text" id="library-name" class="form-control" placeholder="Anime Bibliothek" required>
+                        </div>
+                        <div class="col-md-6">
+                            <label for="library-path" class="form-label">Pfad</label>
+                            <input type="text" id="library-path" class="form-control" placeholder="D:\\Medien\\Animes" required>
+                        </div>
+                        <div class="col-md-2 align-self-end">
+                            <div class="form-check mt-4">
+                                <input class="form-check-input" type="checkbox" id="library-default">
+                                <label class="form-check-label" for="library-default">Standard</label>
+                            </div>
+                        </div>
+                        <div class="col-12 text-end">
+                            <button type="submit" class="btn btn-primary">Bibliothek hinzufügen</button>
+                        </div>
+                    </form>
+                    <div id="libraries-list" class="mt-4">
+                        <div class="text-muted">Noch keine Bibliotheken geladen.</div>
+                    </div>
+                </div>
+            </div>
+            <div class="row mb-3">
+                <div class="col-md-6">
+                    <div class="input-group">
+                        <input type="text" id="library-search" class="form-control" placeholder="In Mediathek suchen...">
+                        <select id="library-type" class="form-select" style="max-width: 120px;">
+                            <option value="all">Alle</option>
+                            <option value="series">Serien</option>
+                            <option value="anime">Animes</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="col-md-6 text-end">
+                    <button id="refresh-library-btn" class="btn btn-primary">Aktualisieren</button>
+                </div>
+            </div>
+
+            <div id="library-content">
+                <div class="alert alert-info">Lade Mediathek...</div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a global download status header to the shared base template so every page exposes the elements expected by the JavaScript progress handlers
- restyle the new header, keep the cancel button hidden until a job is active, and reuse the markup without clashing with the status tab
- update the main frontend script to manage both the global banner and the status tab elements while wiring cancel events to every available button
- refactor the index page to extend the base layout and give the card-specific elements unique identifiers

## Testing
- pytest tests/test_language_guard.py *(fails: ModuleNotFoundError: No module named 'dotenv')*


------
https://chatgpt.com/codex/tasks/task_e_68d351bd8eb083319dcfd8257f361152