### PR TITLE
Fix core runtime and language handling bugs

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, render_template, request, jsonify
+from flask import Flask, render_template, request, jsonify, redirect, url_for
 from flask_sqlalchemy import SQLAlchemy
 from flask_socketio import SocketIO
 from datetime import datetime
@@ -87,7 +87,9 @@ def _emit_progress(pct, speed, eta, msg):
         "job": _copy_progress(),
         "is_downloading": bool(getattr(scraper.download_status, "is_downloading", False)),
     }
-    socketio.emit("download_progress", payload, broadcast=True)
+    # Omitting a room broadcasts to all clients. `broadcast=True` is not a
+    # supported python-socketio Server.emit keyword and raises at runtime.
+    socketio.emit("download_progress", payload)
 
 
 def _prepare_progress(series_name: Optional[str] = None) -> None:
@@ -350,6 +352,21 @@ if config.get('download.scan_on_startup', False):
 def index():
     return render_template('index.html')
 
+
+@app.route('/library')
+def library_page():
+    return redirect('/#library')
+
+
+@app.route('/settings')
+def settings_page():
+    return redirect('/#settings')
+
+
+@app.route('/about')
+def about_page():
+    return render_template('about.html')
+
 @app.route('/gemini')
 def gemini_settings():
     return render_template('gemini_settings.html',
@@ -361,7 +378,14 @@ def gemini_settings():
 @app.route('/search')
 def search():
     query = request.args.get('q', '').strip()
-    series_type = request.args.get('type', 'all')
+    requested_type = request.args.get('type')
+
+    # The navbar submits to this route without an API type. Send browser
+    # searches back to the dashboard instead of displaying raw JSON.
+    if requested_type is None:
+        return redirect(f"{url_for('index', q=query)}#search")
+
+    series_type = requested_type or 'all'
 
     if not query:
         return jsonify([])

--- a/config_manager.py
+++ b/config_manager.py
@@ -6,6 +6,7 @@ Combines settings from .env, config.json, and environment variables.
 import os
 import json
 import logging
+from copy import deepcopy
 from typing import Any, Dict, List, Optional, Tuple
 from dotenv import load_dotenv
 
@@ -230,7 +231,9 @@ class ConfigManager:
     def _log_config(self) -> None:
         """Log the current configuration (excluding sensitive data)."""
         # Create a copy of the config without sensitive data
-        safe_config = self.config.copy()
+        # A shallow copy would share all nested dictionaries with the active
+        # configuration and replace real API keys with the masked log value.
+        safe_config = deepcopy(self.config)
 
         # Remove sensitive data
         if 'real_debrid' in safe_config and 'api_key' in safe_config['real_debrid']:

--- a/language_guard.py
+++ b/language_guard.py
@@ -502,10 +502,20 @@ def guess_audio_and_dub(label: str) -> Tuple[Optional[str], Optional[str]]:
             dub_lang = lang
             break
 
-    # Detect audio language
+    # A dub label describes the target language, not necessarily the original
+    # audio language. Remove the matched dub phrase before looking for an
+    # explicit audio language (e.g. "Japanese German Dub" -> ja/de, while
+    # "German Dub" -> None/de).
+    audio_label = label_l
+    if dub_lang:
+        for pattern in DUB_PATTERNS[dub_lang]:
+            audio_label = re.sub(pattern, " ", audio_label, flags=re.IGNORECASE)
+        audio_label = re.sub(r'\s+', ' ', audio_label).strip()
+
+    # Detect an explicitly named original audio language.
     audio_lang: Optional[str] = None
     for lang, pats in LANG_MAP.items():
-        if _match_any(label_l, pats):
+        if _match_any(audio_label, pats):
             audio_lang = lang
             break
 
@@ -688,7 +698,7 @@ def pick_best(variants: Iterable[EpisodeVariant]) -> Optional[EpisodeVariant]:
             for v in vs:
                 if v.audio_lang == a_pref:
                     return v
-    return vs[0] if vs else None
+    return None
 
 def sort_by_preference(variants: Iterable[EpisodeVariant]) -> List[EpisodeVariant]:
     """Sort variants by language preference."""
@@ -717,13 +727,25 @@ def pick_best_with_quality(variants: Iterable[EpisodeVariant]) -> Optional[Episo
         by_pref.setdefault(key, []).append(v)
 
     # Quality order preference
-    quality_order = ["2160p", "1440p", "1080p", "720p", "480p", "360p"]
+    quality_order = {
+        "8k": 0,
+        "4320p": 0,
+        "4k": 1,
+        "uhd": 1,
+        "2160p": 1,
+        "1440p": 2,
+        "1080p": 3,
+        "full hd": 3,
+        "fhd": 3,
+        "hd": 4,
+        "720p": 4,
+        "480p": 5,
+        "sd": 5,
+        "360p": 6,
+    }
     def qrank(q):
         q = (q or "").lower()
-        try:
-            return quality_order.index(q)
-        except ValueError:
-            return 999
+        return quality_order.get(q, 999)
 
     for _, lst in by_pref.items():
         return sorted(lst, key=lambda v: qrank(v.quality))[0]

--- a/language_utils.py
+++ b/language_utils.py
@@ -113,17 +113,14 @@ def subtitle_codes_from_filename(filename: str) -> Set[str]:
 
 
 def strip_language_tag_suffix(name: str) -> str:
-    result = name
-    while True:
-        match = _SUFFIX_PATTERN.search(result)
-        if not match:
-            break
+    def remove_if_language_tag(match: re.Match) -> str:
         token = _normalize_token(match.group(1))
-        if _extract_language_code_from_token(token, "dub", _LANGUAGE_CANONICAL_TOKENS) or _extract_language_code_from_token(token, "sub", _SUBTITLE_CANONICAL_TOKENS):
-            result = result[:match.start()].rstrip()
-            continue
-        break
-    return result.rstrip()
+        is_dub = _extract_language_code_from_token(token, "dub", _LANGUAGE_CANONICAL_TOKENS)
+        is_sub = _extract_language_code_from_token(token, "sub", _SUBTITLE_CANONICAL_TOKENS)
+        return "" if is_dub or is_sub else match.group(0)
+
+    result = _TAG_PATTERN.sub(remove_if_language_tag, name)
+    return re.sub(r"\s{2,}", " ", result).strip()
 
 
 def get_language_dub_tag(lang_code: str) -> str:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest==9.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ Flask-SocketIO==5.3.6
 requests==2.31.0
 beautifulsoup4==4.12.2
 lxml==4.9.3
+yt-dlp==2026.7.4
 
 # Language detection
 faster-whisper==0.9.0
@@ -18,3 +19,4 @@ google-generativeai==0.3.2
 # Utilities
 python-socketio==5.9.0
 python-engineio==4.7.1
+python-dotenv==1.2.2

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -73,18 +73,48 @@ let isDownloading = false;
 
 // Event Listeners
 document.addEventListener('DOMContentLoaded', () => {
-    // Live search with debounce
-    searchInput.addEventListener('input', handleSearchInput);
-
-    // Type filter change
-    searchType.addEventListener('change', () => {
-        if (searchInput.value.trim().length > 0) {
-            performSearch(searchInput.value.trim(), searchType.value);
+    // Open dashboard tabs addressed by navigation redirects such as /#library.
+    const tabId = window.location.hash.slice(1);
+    if (tabId && window.bootstrap) {
+        const tabTrigger = document.querySelector(`[data-bs-target="#${CSS.escape(tabId)}"]`);
+        if (tabTrigger) {
+            bootstrap.Tab.getOrCreateInstance(tabTrigger).show();
         }
+    }
+
+    document.querySelectorAll('[data-bs-toggle="tab"]').forEach((tabTrigger) => {
+        tabTrigger.addEventListener('shown.bs.tab', (event) => {
+            const target = event.target.getAttribute('data-bs-target');
+            if (target) {
+                history.replaceState(null, '', target);
+            }
+        });
     });
 
+    // Live search with debounce
+    if (searchInput) {
+        searchInput.addEventListener('input', handleSearchInput);
+
+        const initialQuery = new URLSearchParams(window.location.search).get('q');
+        if (initialQuery) {
+            searchInput.value = initialQuery;
+            performSearch(initialQuery, searchType ? searchType.value : 'all');
+        }
+    }
+
+    // Type filter change
+    if (searchType && searchInput) {
+        searchType.addEventListener('change', () => {
+            if (searchInput.value.trim().length > 0) {
+                performSearch(searchInput.value.trim(), searchType.value);
+            }
+        });
+    }
+
     // Update database button
-    updateDbBtn.addEventListener('click', updateDatabase);
+    if (updateDbBtn) {
+        updateDbBtn.addEventListener('click', updateDatabase);
+    }
 
     // Load Aniworld list
     if (loadAnimeListBtn) {
@@ -92,10 +122,14 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     // VOE.sx download button
-    voeDownloadBtn.addEventListener('click', startVoeDownload);
+    if (voeDownloadBtn) {
+        voeDownloadBtn.addEventListener('click', startVoeDownload);
+    }
 
     // Reset session button
-    resetSessionBtn.addEventListener('click', resetSession);
+    if (resetSessionBtn) {
+        resetSessionBtn.addEventListener('click', resetSession);
+    }
 
     // Cancel download button
     cancelButtons.forEach((btn) => {
@@ -107,23 +141,37 @@ document.addEventListener('DOMContentLoaded', () => {
     setInterval(checkDownloadStatus, 5000);
 
     // Load download directory
-    loadDownloadDirectory();
+    if (downloadDirInput && currentDownloadDir) {
+        loadDownloadDirectory();
+    }
 
     // Load database statistics
-    loadDatabaseStats();
+    if (dbStats) {
+        loadDatabaseStats();
+    }
 
     // Load library content
-    loadLibraryContent();
-    loadLibraries();
+    if (libraryContent) {
+        loadLibraryContent();
+    }
+    if (librariesList) {
+        loadLibraries();
+    }
 
     // Settings event listeners
-    downloadDirForm.addEventListener('submit', (e) => {
-        e.preventDefault();
-        updateDownloadDirectory();
-    });
+    if (downloadDirForm) {
+        downloadDirForm.addEventListener('submit', (e) => {
+            e.preventDefault();
+            updateDownloadDirectory();
+        });
+    }
 
-    scanDirBtn.addEventListener('click', scanDirectory);
-    clearDbBtn.addEventListener('click', clearDatabase);
+    if (scanDirBtn) {
+        scanDirBtn.addEventListener('click', scanDirectory);
+    }
+    if (clearDbBtn) {
+        clearDbBtn.addEventListener('click', clearDatabase);
+    }
 
     // Library event listeners
     if (libraryForm) {

--- a/templates/about.html
+++ b/templates/about.html
@@ -1,0 +1,18 @@
+{% extends 'base.html' %}
+
+{% block title %}Über ScaP{% endblock %}
+
+{% block content %}
+<div class="container mt-4">
+    <h1>Über ScaP</h1>
+    <div class="card mb-4">
+        <div class="card-body">
+            <h2 class="h5">Stream Scraper and Processor</h2>
+            <p class="mb-0">
+                ScaP verwaltet lokale Medienbibliotheken, Downloads, Sprachprüfung
+                und Metadaten in einer gemeinsamen Oberfläche.
+            </p>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -1,0 +1,21 @@
+import json
+
+from config_manager import ConfigManager
+
+
+def test_logging_does_not_replace_active_api_keys(tmp_path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps({
+            "real_debrid": {"api_key": "rd-secret"},
+            "jellyfin": {"api_key": "jellyfin-secret"},
+            "gemini": {"api_key": "gemini-secret"},
+        }),
+        encoding="utf-8",
+    )
+
+    config = ConfigManager(config_file=str(config_path), env_file=str(tmp_path / ".env"))
+
+    assert config.get("real_debrid.api_key") == "rd-secret"
+    assert config.get("jellyfin.api_key") == "jellyfin-secret"
+    assert config.get("gemini.api_key") == "gemini-secret"

--- a/tests/test_language_guard.py
+++ b/tests/test_language_guard.py
@@ -200,7 +200,8 @@ class TestVariantSelection:
         assert best.audio_lang == "de"
         assert best.url == "https://example.com/de"
 
-    def test_pick_best_german_dub_priority(self):
+    @patch("language_guard._get_lang_priority", return_value=[("en", "de"), ("de", None), ("en", None), ("ja", None)])
+    def test_pick_best_german_dub_priority(self, _mock_priority):
         """Test that German dub variants are picked before regular German."""
         variants = [
             EpisodeVariant(url="https://example.com/de", source="test", audio_lang="de"),
@@ -226,7 +227,8 @@ class TestVariantSelection:
 
         assert best is None
 
-    def test_sort_by_preference(self):
+    @patch("language_guard._get_lang_priority", return_value=[("de", None), ("en", "de"), ("en", None), ("ja", None)])
+    def test_sort_by_preference(self, _mock_priority):
         """Test sorting variants by preference."""
         variants = [
             EpisodeVariant(url="https://example.com/ja", source="test", audio_lang="ja"),


### PR DESCRIPTION
## Behobene Bugs

- verhindert Abstürze bei Download-Fortschrittsmeldungen durch das ungültige Socket.IO-Argument `broadcast=True`
- verhindert, dass aktive Real-Debrid-, Jellyfin- und Gemini-Schlüssel beim Logging versehentlich durch `***` ersetzt werden
- erkennt `German Dub` korrekt als Dub-Sprache statt als Originalsprache
- erkennt Kombinationen wie `Japanese German Dub` korrekt als Japanisch/Deutsch
- wählt keine unpassende Sprachvariante mehr als stillen Fallback
- sortiert `4K`, `UHD`, `FHD`, `HD` und weitere Qualitätsbezeichnungen korrekt
- entfernt Sprach-Tags auch dann zuverlässig, wenn danach noch weitere Tags folgen
- verhindert JavaScript-Fehler auf Seiten ohne Dashboard-Elemente, etwa der Gemini-Seite
- repariert die bisher nicht vorhandenen Routen für Bibliothek, Einstellungen und Über
- leitet die Navbar-Suche zurück in die Dashboard-Suche statt auf eine rohe JSON-Ausgabe
- ergänzt die fehlenden Runtime-Abhängigkeiten `yt-dlp` und `python-dotenv`
- behebt die Pytest-Kollision der zwei gleich benannten Language-Guard-Dateien

## Tests

- `25 passed` mit Pytest
- `node --check static/js/main.js`
- Flask-Smoke-Test für Dashboard, Gemini, Über, Bibliothek, Einstellungen, Suche, Downloadstatus, Bibliotheken und Medienstatistik
- `git diff --check`

## Umfang

Der Branch basiert auf dem bereits gemergten Design-PR #4. Sicherheits-Hardening und neue Queue-Funktionen sind bewusst nicht Teil dieses Bugfix-Passes.