### PR TITLE
Complete persistent download queue and episode workflow

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,6 +5,17 @@ zunächst auf zuverlässiger Funktion, stabilen Downloads und einer guten
 Bedienung. Sicherheits-Hardening wird eingeplant, bevor ScaP für Zugriffe aus
 dem Netzwerk geöffnet wird.
 
+## Aktueller Update-Plan
+
+- **Erledigt:** Design-Grundlage sowie zentrale Download-, Konfigurations- und
+  Spracherkennungsfehler
+- **PR #6:** Bibliotheks-Synchronisation reparieren und ungenutzte Pakete
+  `lxml` sowie `google-generativeai` entfernen
+- **Dieser PR:** persistente Serien-Queue mit Neustart-Wiederaufnahme,
+  Fortschritt, Verlauf, Abbrechen und Wiederholen
+- **Als Nächstes:** Pause/Fortsetzen und Fortschritt pro Episode, danach
+  Staffel-/Episodenauswahl vor dem Download
+
 ## Priorität 1: Bugs und Stabilität
 
 - reproduzierbare Start-, Datenbank- und Bibliotheksfehler beheben
@@ -15,11 +26,12 @@ dem Netzwerk geöffnet wird.
 
 ## Priorität 2: Persistente Download-Queue
 
-- mehrere Serien und Episoden vormerken
-- Zustände `pending`, `downloading`, `completed`, `failed` und `cancelled`
-- Pause, Fortsetzen, Abbrechen und Wiederholen
-- Fortschritt pro Episode und für den gesamten Auftrag
-- Queue und Verlauf nach einem Neustart wiederherstellen
+- [x] mehrere Serien vormerken
+- [x] Zustände `pending`, `downloading`, `completed`, `failed` und `cancelled`
+- [x] Abbrechen und Wiederholen
+- [x] Queue und Verlauf nach einem Neustart wiederherstellen
+- [ ] Pause und Fortsetzen
+- [ ] Fortschritt pro Episode zusätzlich zum gesamten Auftrag
 
 ## Priorität 3: Download-Workflow
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,10 +11,10 @@ dem Netzwerk geöffnet wird.
   Spracherkennungsfehler
 - **PR #6:** Bibliotheks-Synchronisation reparieren und ungenutzte Pakete
   `lxml` sowie `google-generativeai` entfernen
-- **Dieser PR:** persistente Serien-Queue mit Neustart-Wiederaufnahme,
-  Fortschritt, Verlauf, Abbrechen und Wiederholen
-- **Als Nächstes:** Pause/Fortsetzen und Fortschritt pro Episode, danach
-  Staffel-/Episodenauswahl vor dem Download
+- **Dieser PR:** vollständige persistente Serien-Queue mit Auswahl,
+  Episodenfortschritt, Pause/Fortsetzen, Verlauf, Abbrechen und Wiederholen
+- **Als Nächstes:** verfügbare Qualität, Audio und Untertitel vor dem Start
+  anzeigen sowie vorhandene Episoden und Speicherbedarf vorab prüfen
 
 ## Priorität 1: Bugs und Stabilität
 
@@ -27,11 +27,12 @@ dem Netzwerk geöffnet wird.
 ## Priorität 2: Persistente Download-Queue
 
 - [x] mehrere Serien vormerken
-- [x] Zustände `pending`, `downloading`, `completed`, `failed` und `cancelled`
+- [x] Zustände `pending`, `downloading`, `paused`, `completed`, `failed` und `cancelled`
 - [x] Abbrechen und Wiederholen
 - [x] Queue und Verlauf nach einem Neustart wiederherstellen
-- [ ] Pause und Fortsetzen
-- [ ] Fortschritt pro Episode zusätzlich zum gesamten Auftrag
+- [x] Pause und Fortsetzen
+- [x] Fortschritt pro Episode zusätzlich zum gesamten Auftrag
+- [x] Staffel- und Episodenauswahl vor dem Download
 
 ## Priorität 3: Download-Workflow
 

--- a/app.py
+++ b/app.py
@@ -1,11 +1,13 @@
 from flask import Flask, render_template, request, jsonify, redirect, url_for
 from flask_sqlalchemy import SQLAlchemy
 from flask_socketio import SocketIO
-from datetime import datetime
+from sqlalchemy import inspect, text
+from datetime import datetime, timezone
 from typing import Optional
 from pathlib import Path
 import os
 import json
+import secrets
 from scraper import StreamScraper
 import logging
 import threading
@@ -27,13 +29,18 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+
+def utc_now() -> datetime:
+    """Return a UTC timestamp compatible with SQLite's naive DateTime fields."""
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
 BASE_DIR = Path(__file__).resolve().parent
 
 app = Flask(__name__)
 streams_db_path = Path(os.environ.get('SCAP_STREAMS_DB_PATH', BASE_DIR / 'streams.db')).expanduser().resolve()
 app.config['SQLALCHEMY_DATABASE_URI'] = f'sqlite:///{streams_db_path.as_posix()}'
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-app.config['SECRET_KEY'] = 'streamscraper-secret-key'
+app.config['SECRET_KEY'] = os.environ.get('SCAP_SECRET_KEY') or secrets.token_hex(32)
 db = SQLAlchemy(app)
 socketio = SocketIO(app, cors_allowed_origins="*", async_mode="threading")
 
@@ -59,7 +66,7 @@ def _copy_progress() -> dict:
         }
 
 
-def _emit_progress(pct, speed, eta, msg):
+def _emit_progress(pct, speed, eta, msg, job_payload=None):
     with _progress_lock:
         if isinstance(pct, (int, float)):
             current_progress["progress"] = max(0.0, min(100.0, float(pct)))
@@ -84,8 +91,8 @@ def _emit_progress(pct, speed, eta, msg):
             current_progress["message"] = str(msg)
 
     payload = {
-        "job": _copy_progress(),
-        "is_downloading": bool(getattr(scraper.download_status, "is_downloading", False)),
+        "job": job_payload or _copy_progress(),
+        "is_downloading": bool(job_payload) or bool(getattr(scraper.download_status, "is_downloading", False)),
     }
     # Omitting a room broadcasts to all clients. `broadcast=True` is not a
     # supported python-socketio Server.emit keyword and raises at runtime.
@@ -121,7 +128,7 @@ class Series(db.Model):
     title = db.Column(db.String(200), nullable=False)
     url = db.Column(db.String(500), unique=True, nullable=False)
     type = db.Column(db.String(50))  # 'anime' oder 'series'
-    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    created_at = db.Column(db.DateTime, default=utc_now)
     episodes = db.relationship('Episode', backref='series', lazy=True)
     library_assignment = db.relationship(
         'SeriesLibrary',
@@ -137,7 +144,7 @@ class Episode(db.Model):
     episode = db.Column(db.Integer)
     title = db.Column(db.String(200))
     status = db.Column(db.String(50))  # 'pending', 'downloading', 'completed', 'failed'
-    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    created_at = db.Column(db.DateTime, default=utc_now)
 
 
 class DownloadJob(db.Model):
@@ -150,8 +157,14 @@ class DownloadJob(db.Model):
     progress = db.Column(db.Float, nullable=False, default=0.0)
     message = db.Column(db.String(500), nullable=False, default='Wartet')
     error = db.Column(db.Text)
+    selection_json = db.Column(db.Text)
     cancel_requested = db.Column(db.Boolean, nullable=False, default=False)
-    created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow, index=True)
+    current_season = db.Column(db.Integer)
+    current_episode = db.Column(db.Integer)
+    completed_episodes = db.Column(db.Integer, nullable=False, default=0)
+    total_episodes = db.Column(db.Integer, nullable=False, default=0)
+    episode_progress = db.Column(db.Float, nullable=False, default=0.0)
+    created_at = db.Column(db.DateTime, nullable=False, default=utc_now, index=True)
     started_at = db.Column(db.DateTime)
     finished_at = db.Column(db.DateTime)
 
@@ -161,8 +174,8 @@ class Library(db.Model):
     name = db.Column(db.String(120), nullable=False)
     path = db.Column(db.String(500), nullable=False)
     is_default = db.Column(db.Boolean, default=False, nullable=False)
-    created_at = db.Column(db.DateTime, default=datetime.utcnow)
-    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    created_at = db.Column(db.DateTime, default=utc_now)
+    updated_at = db.Column(db.DateTime, default=utc_now, onupdate=utc_now)
     series_assignments = db.relationship(
         'SeriesLibrary',
         back_populates='library',
@@ -174,7 +187,7 @@ class SeriesLibrary(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     series_id = db.Column(db.Integer, db.ForeignKey('series.id'), nullable=False, unique=True)
     library_id = db.Column(db.Integer, db.ForeignKey('library.id'), nullable=False)
-    assigned_at = db.Column(db.DateTime, default=datetime.utcnow)
+    assigned_at = db.Column(db.DateTime, default=utc_now)
 
     series = db.relationship('Series', back_populates='library_assignment')
     library = db.relationship('Library', back_populates='series_assignments')
@@ -192,6 +205,13 @@ def library_to_dict(library: Library) -> dict:
 
 
 def download_job_to_dict(job: DownloadJob) -> dict:
+    selection = None
+    if job.selection_json:
+        try:
+            selection = json.loads(job.selection_json)
+        except (TypeError, ValueError):
+            selection = None
+
     return {
         'id': job.id,
         'url': job.url,
@@ -202,11 +222,35 @@ def download_job_to_dict(job: DownloadJob) -> dict:
         'progress': float(job.progress or 0.0),
         'message': job.message or '',
         'error': job.error,
+        'selection': selection,
+        'selected_episode_count': sum(len(episodes) for episodes in selection.values()) if selection else None,
         'cancel_requested': bool(job.cancel_requested),
+        'current_season': job.current_season,
+        'current_episode': job.current_episode,
+        'completed_episodes': int(job.completed_episodes or 0),
+        'total_episodes': int(job.total_episodes or 0),
+        'episode_progress': float(job.episode_progress or 0.0),
         'created_at': job.created_at.isoformat() if job.created_at else None,
         'started_at': job.started_at.isoformat() if job.started_at else None,
         'finished_at': job.finished_at.isoformat() if job.finished_at else None,
     }
+
+
+def normalize_episode_selection(value) -> Optional[dict[str, list[int]]]:
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise ValueError('Episodenauswahl muss nach Staffeln gruppiert sein')
+
+    normalized: dict[str, list[int]] = {}
+    for raw_season, raw_episodes in value.items():
+        season = _as_int(raw_season)
+        if not season or season < 1 or not isinstance(raw_episodes, list):
+            continue
+        episodes = sorted({episode for item in raw_episodes if (episode := _as_int(item)) and episode > 0})
+        if episodes:
+            normalized[str(season)] = episodes
+    return normalized
 
 
 def recover_interrupted_download_jobs() -> int:
@@ -222,6 +266,32 @@ def recover_interrupted_download_jobs() -> int:
     if interrupted_jobs:
         db.session.commit()
     return len(interrupted_jobs)
+
+
+def ensure_download_job_schema() -> int:
+    """Add queue columns introduced after the first local queue preview."""
+    inspector = inspect(db.engine)
+    if 'download_job' not in inspector.get_table_names():
+        return 0
+
+    existing = {column['name'] for column in inspector.get_columns('download_job')}
+    additions = {
+        'selection_json': 'TEXT',
+        'current_season': 'INTEGER',
+        'current_episode': 'INTEGER',
+        'completed_episodes': 'INTEGER NOT NULL DEFAULT 0',
+        'total_episodes': 'INTEGER NOT NULL DEFAULT 0',
+        'episode_progress': 'FLOAT NOT NULL DEFAULT 0',
+    }
+    added = 0
+    for column, definition in additions.items():
+        if column in existing:
+            continue
+        db.session.execute(text(f'ALTER TABLE download_job ADD COLUMN {column} {definition}'))
+        added += 1
+    if added:
+        db.session.commit()
+    return added
 
 
 def persist_libraries_to_config() -> None:
@@ -356,6 +426,7 @@ def determine_series_target_path(url: str, series_id: Optional[int] = None, libr
 # Erstelle die Datenbank
 with app.app_context():
     db.create_all()
+    ensure_download_job_schema()
     sync_libraries_from_config()
     recover_interrupted_download_jobs()
 
@@ -374,45 +445,78 @@ scraper = StreamScraper(
 _queue_wakeup = threading.Event()
 _queue_start_lock = threading.Lock()
 _queue_db_lock = threading.Lock()
+_queue_state_lock = threading.Lock()
 _queue_worker_started = False
+_active_queue_job_id = None
+
+
+def _set_active_queue_job(job_id: Optional[int]) -> None:
+    global _active_queue_job_id
+    with _queue_state_lock:
+        _active_queue_job_id = job_id
+
+
+def _get_active_queue_job() -> Optional[int]:
+    with _queue_state_lock:
+        return _active_queue_job_id
 
 
 def _persist_job_progress(job_id: int, pct, speed, eta, message) -> None:
+    job_payload = None
     try:
         with _queue_db_lock:
             with app.app_context():
                 job = db.session.get(DownloadJob, job_id)
-                if not job or job.status != 'downloading':
+                if not job or job.status not in ('downloading', 'paused'):
                     return
+                live_status = scraper.download_status.get_status()
                 if isinstance(pct, (int, float)):
-                    job.progress = max(0.0, min(100.0, float(pct)))
+                    job.episode_progress = max(0.0, min(100.0, float(pct)))
+                job.current_season = _as_int(live_status.get('current_season'))
+                job.current_episode = _as_int(live_status.get('current_episode'))
+                job.completed_episodes = max(0, _as_int(live_status.get('completed_episodes')) or 0)
+                job.total_episodes = max(0, _as_int(live_status.get('total_episodes')) or 0)
+                if job.total_episodes:
+                    overall = (
+                        job.completed_episodes + (job.episode_progress / 100.0)
+                    ) / job.total_episodes * 100.0
+                    job.progress = max(0.0, min(100.0, overall))
+                elif isinstance(pct, (int, float)):
+                    job.progress = job.episode_progress
                 if message:
                     job.message = str(message)[:500]
                 db.session.commit()
+                job_payload = download_job_to_dict(job)
     except Exception:
         logger.exception('Fortschritt für Queue-Download %s konnte nicht gespeichert werden', job_id)
 
-    _emit_progress(pct, speed, eta, message)
+    _emit_progress(pct, speed, eta, message, job_payload=job_payload)
 
 
 def _run_download_queue() -> None:
     while True:
+        job_id = None
         try:
             _queue_wakeup.clear()
             job_data = None
 
             with _queue_db_lock:
                 with app.app_context():
-                    job = DownloadJob.query.filter_by(status='pending').order_by(
+                    paused_job = DownloadJob.query.filter_by(status='paused').order_by(
                         DownloadJob.created_at.asc(), DownloadJob.id.asc()
                     ).first()
+                    job = None
+                    if not paused_job:
+                        job = DownloadJob.query.filter_by(status='pending').order_by(
+                            DownloadJob.created_at.asc(), DownloadJob.id.asc()
+                        ).first()
                     if job:
                         job.status = 'downloading'
                         job.progress = 0.0
                         job.message = 'Download wird gestartet'
                         job.error = None
                         job.cancel_requested = False
-                        job.started_at = datetime.utcnow()
+                        job.started_at = utc_now()
                         job.finished_at = None
                         db.session.commit()
                         job_data = {
@@ -420,6 +524,7 @@ def _run_download_queue() -> None:
                             'url': job.url,
                             'series_name': job.series_name,
                             'series_path': job.series_path,
+                            'selection': json.loads(job.selection_json) if job.selection_json else None,
                         }
 
             if not job_data:
@@ -427,12 +532,14 @@ def _run_download_queue() -> None:
                 continue
 
             job_id = job_data['id']
+            _set_active_queue_job(job_id)
             _prepare_progress(job_data['series_name'])
             error = None
             try:
                 scraper.start_download(
                     job_data['url'],
                     series_path=job_data['series_path'],
+                    selection=job_data['selection'],
                     progress_cb=lambda pct, speed, eta, message, current_id=job_id: _persist_job_progress(
                         current_id, pct, speed, eta, message
                     ),
@@ -455,11 +562,15 @@ def _run_download_queue() -> None:
                         else:
                             job.status = 'completed'
                             job.progress = 100.0
+                            job.episode_progress = 100.0
                             job.message = 'Download abgeschlossen'
-                        job.finished_at = datetime.utcnow()
+                        job.finished_at = utc_now()
                         db.session.commit()
+            _set_active_queue_job(None)
         except Exception:
             logger.exception('Queue-Worker konnte einen Auftrag nicht verarbeiten')
+            if job_id == _get_active_queue_job():
+                _set_active_queue_job(None)
             _queue_wakeup.wait(timeout=1.0)
 
 
@@ -479,6 +590,11 @@ def _enqueue_download(data: dict) -> tuple[DownloadJob, Optional[Library]]:
     if not url:
         raise ValueError('URL ist erforderlich')
 
+    selection_was_provided = 'selection' in data
+    selection = normalize_episode_selection(data.get('selection'))
+    if selection_was_provided and not selection:
+        raise ValueError('Bitte mindestens eine Episode auswählen')
+
     series_id = _as_int(data.get('series_id'))
     library_id = _as_int(data.get('library_id'))
     library, series_path = determine_series_target_path(
@@ -496,8 +612,12 @@ def _enqueue_download(data: dict) -> tuple[DownloadJob, Optional[Library]]:
         series_name=series_name,
         series_path=series_path,
         library_id=library.id if library else None,
+        selection_json=json.dumps(selection, sort_keys=True) if selection else None,
         status='pending',
         progress=0.0,
+        completed_episodes=0,
+        total_episodes=sum(len(episodes) for episodes in selection.values()) if selection else 0,
+        episode_progress=0.0,
         message='Wartet in der Queue',
     )
     db.session.add(job)
@@ -508,7 +628,7 @@ def _enqueue_download(data: dict) -> tuple[DownloadJob, Optional[Library]]:
 
 
 def _current_status_payload() -> dict:
-    active_job = DownloadJob.query.filter_by(status='downloading').order_by(
+    active_job = DownloadJob.query.filter(DownloadJob.status.in_(('downloading', 'paused'))).order_by(
         DownloadJob.started_at.asc(), DownloadJob.id.asc()
     ).first()
     pending_jobs = DownloadJob.query.filter_by(status='pending').order_by(
@@ -519,11 +639,15 @@ def _current_status_payload() -> dict:
     ).order_by(DownloadJob.finished_at.desc(), DownloadJob.id.desc()).limit(20).all()
 
     active = download_job_to_dict(active_job) if active_job else None
-    if active:
+    if active and active_job.id == _get_active_queue_job():
         live_status = scraper.download_status.get_status()
         active.update({
+            'current_season': live_status.get('current_season'),
             'current_episode': live_status.get('current_episode'),
+            'completed_episodes': live_status.get('completed_episodes'),
             'total_episodes': live_status.get('total_episodes'),
+            'episode_progress': live_status.get('episode_progress'),
+            'is_paused': live_status.get('is_paused'),
         })
 
     return {
@@ -531,6 +655,7 @@ def _current_status_payload() -> dict:
         'queue': [download_job_to_dict(job) for job in pending_jobs],
         'history': [download_job_to_dict(job) for job in history_jobs],
         'is_downloading': active_job is not None,
+        'is_paused': bool(active_job and active_job.status == 'paused'),
     }
 
 
@@ -676,6 +801,22 @@ def start_download():
         db.session.rollback()
         logger.error(f"Fehler beim Einreihen des Downloads: {e}", exc_info=True)
         return jsonify({'error': str(e)}), 500
+
+
+@app.post('/api/download/catalog')
+def download_catalog():
+    data = request.json or {}
+    url = str(data.get('url', '')).strip()
+    if not url:
+        return jsonify({'ok': False, 'error': 'URL ist erforderlich'}), 400
+    try:
+        catalog = scraper.get_series_catalog(url)
+        if not catalog or not catalog.get('seasons'):
+            return jsonify({'ok': False, 'error': 'Keine Staffeln oder Episoden gefunden'}), 404
+        return jsonify({'ok': True, 'data': catalog}), 200
+    except Exception as exc:
+        logger.error('Episodenauswahl für %s konnte nicht geladen werden: %s', url, exc, exc_info=True)
+        return jsonify({'ok': False, 'error': str(exc)}), 502
 
 
 @app.get("/api/downloads/status")
@@ -981,10 +1122,19 @@ def reset_session():
 def api_cancel():
     """Bricht den aktuellen Download ab."""
     try:
-        active_job = DownloadJob.query.filter_by(status='downloading').first()
+        active_job = DownloadJob.query.filter(DownloadJob.status.in_(('downloading', 'paused'))).first()
         if not active_job and not getattr(scraper.download_status, "is_downloading", False):
             logger.warning("Kein aktiver Download zum Abbrechen")
             return jsonify({"ok": False, "message": "Kein aktiver Download"}), 409
+
+        if active_job and active_job.status == 'paused' and active_job.id != _get_active_queue_job():
+            active_job.status = 'cancelled'
+            active_job.cancel_requested = True
+            active_job.message = 'Pausierten Download abgebrochen'
+            active_job.finished_at = utc_now()
+            db.session.commit()
+            _queue_wakeup.set()
+            return jsonify({"ok": True, "message": "Download abgebrochen"}), 200
 
         cancelled = False
         cancel_callable = getattr(scraper.download_status, "request_cancel", None)
@@ -1023,11 +1173,21 @@ def cancel_download_job(job_id: int):
             job.status = 'cancelled'
             job.cancel_requested = True
             job.message = 'Download aus Queue entfernt'
-            job.finished_at = datetime.utcnow()
+            job.finished_at = utc_now()
             db.session.commit()
             return jsonify({'ok': True, 'job': download_job_to_dict(job)}), 200
 
-        if job.status == 'downloading':
+        if job.status == 'paused' and job.id != _get_active_queue_job():
+            job.status = 'cancelled'
+            job.cancel_requested = True
+            job.message = 'Pausierten Download abgebrochen'
+            job.finished_at = utc_now()
+            db.session.commit()
+            response_job = download_job_to_dict(job)
+            _queue_wakeup.set()
+            return jsonify({'ok': True, 'job': response_job}), 200
+
+        if job.status in ('downloading', 'paused'):
             job.cancel_requested = True
             job.message = 'Abbruch angefordert'
             db.session.commit()
@@ -1037,6 +1197,52 @@ def cancel_download_job(job_id: int):
             return jsonify({'ok': True, 'job': download_job_to_dict(job)}), 200
 
     return jsonify({'ok': False, 'message': 'Download ist nicht mehr aktiv'}), 409
+
+
+@app.post('/api/downloads/<int:job_id>/pause')
+def pause_download_job(job_id: int):
+    with _queue_db_lock:
+        job = db.session.get(DownloadJob, job_id)
+        if not job:
+            return jsonify({'ok': False, 'message': 'Download nicht gefunden'}), 404
+        if job.status != 'downloading' or job.id != _get_active_queue_job():
+            return jsonify({'ok': False, 'message': 'Nur der aktive Download kann pausiert werden'}), 409
+
+        pause_callable = getattr(scraper.download_status, 'request_pause', None)
+        if not callable(pause_callable) or not pause_callable():
+            return jsonify({'ok': False, 'message': 'Download ist noch nicht pausierbar'}), 409
+
+        job.status = 'paused'
+        job.message = 'Download pausiert'
+        db.session.commit()
+        return jsonify({'ok': True, 'job': download_job_to_dict(job)}), 200
+
+
+@app.post('/api/downloads/<int:job_id>/resume')
+def resume_download_job(job_id: int):
+    with _queue_db_lock:
+        job = db.session.get(DownloadJob, job_id)
+        if not job:
+            return jsonify({'ok': False, 'message': 'Download nicht gefunden'}), 404
+        if job.status != 'paused':
+            return jsonify({'ok': False, 'message': 'Download ist nicht pausiert'}), 409
+
+        if job.id == _get_active_queue_job():
+            resume_callable = getattr(scraper.download_status, 'resume', None)
+            if not callable(resume_callable) or not resume_callable():
+                return jsonify({'ok': False, 'message': 'Download konnte nicht fortgesetzt werden'}), 409
+            job.status = 'downloading'
+            job.message = 'Download wird fortgesetzt'
+        else:
+            job.status = 'pending'
+            job.message = 'Fortsetzen in der Queue vorgemerkt'
+            job.started_at = None
+        db.session.commit()
+        response_job = download_job_to_dict(job)
+
+    _ensure_queue_worker()
+    _queue_wakeup.set()
+    return jsonify({'ok': True, 'job': response_job}), 202
 
 
 @app.post('/api/downloads/<int:job_id>/retry')
@@ -1053,6 +1259,10 @@ def retry_download_job(job_id: int):
         job.message = 'Erneut eingereiht'
         job.error = None
         job.cancel_requested = False
+        job.current_season = None
+        job.current_episode = None
+        job.completed_episodes = 0
+        job.episode_progress = 0.0
         job.started_at = None
         job.finished_at = None
         db.session.commit()

--- a/app.py
+++ b/app.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 BASE_DIR = Path(__file__).resolve().parent
 
 app = Flask(__name__)
-streams_db_path = BASE_DIR / 'streams.db'
+streams_db_path = Path(os.environ.get('SCAP_STREAMS_DB_PATH', BASE_DIR / 'streams.db')).expanduser().resolve()
 app.config['SQLALCHEMY_DATABASE_URI'] = f'sqlite:///{streams_db_path.as_posix()}'
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 app.config['SECRET_KEY'] = 'streamscraper-secret-key'
@@ -140,6 +140,22 @@ class Episode(db.Model):
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
 
 
+class DownloadJob(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    url = db.Column(db.String(1000), nullable=False)
+    series_name = db.Column(db.String(200))
+    series_path = db.Column(db.String(1000))
+    library_id = db.Column(db.Integer)
+    status = db.Column(db.String(32), nullable=False, default='pending', index=True)
+    progress = db.Column(db.Float, nullable=False, default=0.0)
+    message = db.Column(db.String(500), nullable=False, default='Wartet')
+    error = db.Column(db.Text)
+    cancel_requested = db.Column(db.Boolean, nullable=False, default=False)
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow, index=True)
+    started_at = db.Column(db.DateTime)
+    finished_at = db.Column(db.DateTime)
+
+
 class Library(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(120), nullable=False)
@@ -173,6 +189,39 @@ def library_to_dict(library: Library) -> dict:
         'created_at': library.created_at.isoformat() if library.created_at else None,
         'updated_at': library.updated_at.isoformat() if library.updated_at else None,
     }
+
+
+def download_job_to_dict(job: DownloadJob) -> dict:
+    return {
+        'id': job.id,
+        'url': job.url,
+        'series_name': job.series_name,
+        'series_path': job.series_path,
+        'library_id': job.library_id,
+        'status': job.status,
+        'progress': float(job.progress or 0.0),
+        'message': job.message or '',
+        'error': job.error,
+        'cancel_requested': bool(job.cancel_requested),
+        'created_at': job.created_at.isoformat() if job.created_at else None,
+        'started_at': job.started_at.isoformat() if job.started_at else None,
+        'finished_at': job.finished_at.isoformat() if job.finished_at else None,
+    }
+
+
+def recover_interrupted_download_jobs() -> int:
+    """Return interrupted jobs to the queue after an application restart."""
+    interrupted_jobs = DownloadJob.query.filter_by(status='downloading').all()
+    for job in interrupted_jobs:
+        job.status = 'pending'
+        job.progress = 0.0
+        job.message = 'Nach Neustart erneut eingereiht'
+        job.cancel_requested = False
+        job.started_at = None
+
+    if interrupted_jobs:
+        db.session.commit()
+    return len(interrupted_jobs)
 
 
 def persist_libraries_to_config() -> None:
@@ -308,6 +357,7 @@ def determine_series_target_path(url: str, series_id: Optional[int] = None, libr
 with app.app_context():
     db.create_all()
     sync_libraries_from_config()
+    recover_interrupted_download_jobs()
 
 # Initialisiere die Media-Datenbank
 media_db = get_media_db(config.get('download.db_path', 'media.db'))
@@ -321,14 +371,170 @@ scraper = StreamScraper(
 )
 
 
+_queue_wakeup = threading.Event()
+_queue_start_lock = threading.Lock()
+_queue_db_lock = threading.Lock()
+_queue_worker_started = False
+
+
+def _persist_job_progress(job_id: int, pct, speed, eta, message) -> None:
+    try:
+        with _queue_db_lock:
+            with app.app_context():
+                job = db.session.get(DownloadJob, job_id)
+                if not job or job.status != 'downloading':
+                    return
+                if isinstance(pct, (int, float)):
+                    job.progress = max(0.0, min(100.0, float(pct)))
+                if message:
+                    job.message = str(message)[:500]
+                db.session.commit()
+    except Exception:
+        logger.exception('Fortschritt für Queue-Download %s konnte nicht gespeichert werden', job_id)
+
+    _emit_progress(pct, speed, eta, message)
+
+
+def _run_download_queue() -> None:
+    while True:
+        try:
+            _queue_wakeup.clear()
+            job_data = None
+
+            with _queue_db_lock:
+                with app.app_context():
+                    job = DownloadJob.query.filter_by(status='pending').order_by(
+                        DownloadJob.created_at.asc(), DownloadJob.id.asc()
+                    ).first()
+                    if job:
+                        job.status = 'downloading'
+                        job.progress = 0.0
+                        job.message = 'Download wird gestartet'
+                        job.error = None
+                        job.cancel_requested = False
+                        job.started_at = datetime.utcnow()
+                        job.finished_at = None
+                        db.session.commit()
+                        job_data = {
+                            'id': job.id,
+                            'url': job.url,
+                            'series_name': job.series_name,
+                            'series_path': job.series_path,
+                        }
+
+            if not job_data:
+                _queue_wakeup.wait()
+                continue
+
+            job_id = job_data['id']
+            _prepare_progress(job_data['series_name'])
+            error = None
+            try:
+                scraper.start_download(
+                    job_data['url'],
+                    series_path=job_data['series_path'],
+                    progress_cb=lambda pct, speed, eta, message, current_id=job_id: _persist_job_progress(
+                        current_id, pct, speed, eta, message
+                    ),
+                )
+            except Exception as exc:
+                error = exc
+                logger.exception('Queue-Download %s fehlgeschlagen', job_id)
+
+            with _queue_db_lock:
+                with app.app_context():
+                    job = db.session.get(DownloadJob, job_id)
+                    if job:
+                        if job.cancel_requested:
+                            job.status = 'cancelled'
+                            job.message = 'Download abgebrochen'
+                        elif error is not None:
+                            job.status = 'failed'
+                            job.message = 'Download fehlgeschlagen'
+                            job.error = str(error)
+                        else:
+                            job.status = 'completed'
+                            job.progress = 100.0
+                            job.message = 'Download abgeschlossen'
+                        job.finished_at = datetime.utcnow()
+                        db.session.commit()
+        except Exception:
+            logger.exception('Queue-Worker konnte einen Auftrag nicht verarbeiten')
+            _queue_wakeup.wait(timeout=1.0)
+
+
+def _ensure_queue_worker() -> None:
+    global _queue_worker_started
+    with _queue_start_lock:
+        if _queue_worker_started:
+            return
+        worker = threading.Thread(target=_run_download_queue, name='download-queue', daemon=True)
+        worker.start()
+        _queue_worker_started = True
+    _queue_wakeup.set()
+
+
+def _enqueue_download(data: dict) -> tuple[DownloadJob, Optional[Library]]:
+    url = str(data.get('url', '')).strip()
+    if not url:
+        raise ValueError('URL ist erforderlich')
+
+    series_id = _as_int(data.get('series_id'))
+    library_id = _as_int(data.get('library_id'))
+    library, series_path = determine_series_target_path(
+        url, series_id=series_id, library_id=library_id
+    )
+
+    series_name = data.get('series_name') if isinstance(data.get('series_name'), str) else None
+    if series_id:
+        series_obj = db.session.get(Series, series_id)
+        if series_obj:
+            series_name = series_obj.title
+
+    job = DownloadJob(
+        url=url,
+        series_name=series_name,
+        series_path=series_path,
+        library_id=library.id if library else None,
+        status='pending',
+        progress=0.0,
+        message='Wartet in der Queue',
+    )
+    db.session.add(job)
+    db.session.commit()
+    _ensure_queue_worker()
+    _queue_wakeup.set()
+    return job, library
+
+
 def _current_status_payload() -> dict:
-    is_downloading = bool(scraper.download_status.is_downloading)
+    active_job = DownloadJob.query.filter_by(status='downloading').order_by(
+        DownloadJob.started_at.asc(), DownloadJob.id.asc()
+    ).first()
+    pending_jobs = DownloadJob.query.filter_by(status='pending').order_by(
+        DownloadJob.created_at.asc(), DownloadJob.id.asc()
+    ).all()
+    history_jobs = DownloadJob.query.filter(
+        DownloadJob.status.in_(('completed', 'failed', 'cancelled'))
+    ).order_by(DownloadJob.finished_at.desc(), DownloadJob.id.desc()).limit(20).all()
+
+    active = download_job_to_dict(active_job) if active_job else None
+    if active:
+        live_status = scraper.download_status.get_status()
+        active.update({
+            'current_episode': live_status.get('current_episode'),
+            'total_episodes': live_status.get('total_episodes'),
+        })
+
     return {
-        "active": _copy_progress() if is_downloading else None,
-        "queue": [],
-        "history": [],
-        "is_downloading": is_downloading,
+        'active': active,
+        'queue': [download_job_to_dict(job) for job in pending_jobs],
+        'history': [download_job_to_dict(job) for job in history_jobs],
+        'is_downloading': active_job is not None,
     }
+
+
+_ensure_queue_worker()
 
 
 # Initialisiere den Gemini Client, wenn aktiviert
@@ -455,46 +661,20 @@ def scrape_list():
 
 @app.route('/api/download', methods=['POST'])
 def start_download():
-    """Startet den Download einer Serie"""
-    data = request.json or {}
-    url = data.get('url')
-    if not url:
-        return jsonify({'error': 'URL ist erforderlich'}), 400
-
-    series_id = _as_int(data.get('series_id'))
-    library_id = _as_int(data.get('library_id'))
-
+    """Legt einen Serien-Download in der persistenten Queue an."""
     try:
-        library, series_path = determine_series_target_path(url, series_id=series_id, library_id=library_id)
-        if library:
-            logger.info(f"Verwende Bibliothek '{library.name}' für den Download")
-
-        if scraper.download_status.is_downloading:
-            logger.warning("Es läuft bereits ein Download")
-            return jsonify({'error': 'Es läuft bereits ein Download!'}), 409
-
-        series_name = data.get('series_name') if isinstance(data.get('series_name'), str) else None
-        if series_id:
-            series_obj = Series.query.get(series_id)
-            if series_obj:
-                series_name = series_obj.title
-
-        _prepare_progress(series_name)
-
-        thread = threading.Thread(
-            target=scraper.start_download,
-            args=(url,),
-            kwargs={'series_path': series_path, 'progress_cb': _emit_progress}
-        )
-        thread.daemon = True
-        thread.start()
-
+        job, library = _enqueue_download(request.json or {})
         return jsonify({
             'status': 'success',
+            'message': 'Download zur Queue hinzugefügt',
+            'job': download_job_to_dict(job),
             'library': library_to_dict(library) if library else None
-        })
+        }), 202
+    except ValueError as exc:
+        return jsonify({'error': str(exc)}), 400
     except Exception as e:
-        logger.error(f"Fehler beim Starten des Downloads: {e}")
+        db.session.rollback()
+        logger.error(f"Fehler beim Einreihen des Downloads: {e}", exc_info=True)
         return jsonify({'error': str(e)}), 500
 
 
@@ -508,52 +688,19 @@ def api_downloads_status():
 
 @app.route('/download', methods=['POST'])
 def download():
-    """Starte einen Download."""
+    """Kompatibler Endpunkt zum Einreihen eines Downloads."""
     try:
-        data = request.json or {}
-        url = data.get('url')
-        logger.debug(f"Download-Anfrage erhalten für URL: {url}")
-
-        if not url:
-            logger.error("Keine URL in der Anfrage gefunden")
-            return jsonify({'error': 'URL fehlt'}), 400
-
-        series_id = _as_int(data.get('series_id'))
-        library_id = _as_int(data.get('library_id'))
-        library, series_path = determine_series_target_path(url, series_id=series_id, library_id=library_id)
-        if library:
-            logger.info(f"Download wird in Bibliothek '{library.name}' abgelegt")
-
-        series_name = data.get('series_name') if isinstance(data.get('series_name'), str) else None
-        if series_id:
-            series_obj = Series.query.get(series_id)
-            if series_obj:
-                series_name = series_obj.title
-
-        # Prüfe ob bereits ein Download läuft
-        if scraper.download_status.is_downloading:
-            logger.warning("Es läuft bereits ein Download")
-            return jsonify({'error': 'Es läuft bereits ein Download!'}), 409
-
-        _prepare_progress(series_name)
-
-        # Starte Download im Hintergrund
-        logger.info(f"Starte Download-Thread für URL: {url}")
-        thread = threading.Thread(
-            target=scraper.start_download,
-            args=(url,),
-            kwargs={'series_path': series_path, 'progress_cb': _emit_progress}
-        )
-        thread.daemon = True
-        thread.start()
-
+        job, library = _enqueue_download(request.json or {})
         return jsonify({
-            'message': 'Download gestartet',
+            'message': 'Download zur Queue hinzugefügt',
+            'job': download_job_to_dict(job),
             'library': library_to_dict(library) if library else None
-        })
-
+        }), 202
+    except ValueError as exc:
+        return jsonify({'error': str(exc)}), 400
     except Exception as e:
-        logger.error(f"Kritischer Fehler beim Download: {str(e)}", exc_info=True)
+        db.session.rollback()
+        logger.error(f"Fehler beim Einreihen des Downloads: {str(e)}", exc_info=True)
         return jsonify({'error': str(e)}), 500
 
 @app.route('/api/download/status')
@@ -834,7 +981,8 @@ def reset_session():
 def api_cancel():
     """Bricht den aktuellen Download ab."""
     try:
-        if not getattr(scraper.download_status, "is_downloading", False):
+        active_job = DownloadJob.query.filter_by(status='downloading').first()
+        if not active_job and not getattr(scraper.download_status, "is_downloading", False):
             logger.warning("Kein aktiver Download zum Abbrechen")
             return jsonify({"ok": False, "message": "Kein aktiver Download"}), 409
 
@@ -844,6 +992,12 @@ def api_cancel():
             cancelled = bool(cancel_callable())
         elif hasattr(scraper.download_status, "cancel_requested"):
             scraper.download_status.cancel_requested = True
+            cancelled = True
+
+        if active_job:
+            active_job.cancel_requested = True
+            active_job.message = 'Abbruch angefordert'
+            db.session.commit()
             cancelled = True
 
         if cancelled:
@@ -856,6 +1010,56 @@ def api_cancel():
     except Exception as exc:
         logger.exception("Cancel failed")
         return jsonify({"ok": False, "error": str(exc)}), 500
+
+
+@app.post('/api/downloads/<int:job_id>/cancel')
+def cancel_download_job(job_id: int):
+    with _queue_db_lock:
+        job = db.session.get(DownloadJob, job_id)
+        if not job:
+            return jsonify({'ok': False, 'message': 'Download nicht gefunden'}), 404
+
+        if job.status == 'pending':
+            job.status = 'cancelled'
+            job.cancel_requested = True
+            job.message = 'Download aus Queue entfernt'
+            job.finished_at = datetime.utcnow()
+            db.session.commit()
+            return jsonify({'ok': True, 'job': download_job_to_dict(job)}), 200
+
+        if job.status == 'downloading':
+            job.cancel_requested = True
+            job.message = 'Abbruch angefordert'
+            db.session.commit()
+            cancel_callable = getattr(scraper.download_status, 'request_cancel', None)
+            if callable(cancel_callable):
+                cancel_callable()
+            return jsonify({'ok': True, 'job': download_job_to_dict(job)}), 200
+
+    return jsonify({'ok': False, 'message': 'Download ist nicht mehr aktiv'}), 409
+
+
+@app.post('/api/downloads/<int:job_id>/retry')
+def retry_download_job(job_id: int):
+    with _queue_db_lock:
+        job = db.session.get(DownloadJob, job_id)
+        if not job:
+            return jsonify({'ok': False, 'message': 'Download nicht gefunden'}), 404
+        if job.status not in ('failed', 'cancelled'):
+            return jsonify({'ok': False, 'message': 'Nur fehlgeschlagene oder abgebrochene Downloads können wiederholt werden'}), 409
+
+        job.status = 'pending'
+        job.progress = 0.0
+        job.message = 'Erneut eingereiht'
+        job.error = None
+        job.cancel_requested = False
+        job.started_at = None
+        job.finished_at = None
+        db.session.commit()
+        response_job = download_job_to_dict(job)
+    _ensure_queue_worker()
+    _queue_wakeup.set()
+    return jsonify({'ok': True, 'job': response_job}), 202
 
 @app.route('/api/settings/download-dir', methods=['GET', 'POST'])
 def manage_download_dir():

--- a/scraper.py
+++ b/scraper.py
@@ -79,11 +79,26 @@ class DownloadStatus:
         self.progress = 0
         self.total_episodes = 0
         self.current_episode = 0
+        self.current_season = 0
+        self.completed_episodes = 0
+        self.episode_progress = 0.0
         self.status_message = ""
         self._lock = threading.Lock()  # Thread-sicherer Lock für Statusaktualisierungen
+        self._pause_condition = threading.Condition(self._lock)
         self.cancel_requested = False  # Flag für Abbruch-Anforderung
+        self.pause_requested = False
 
-    def update(self, title="", progress=None, current_episode=None, total_episodes=None, status_message=""):
+    def update(
+        self,
+        title="",
+        progress=None,
+        current_episode=None,
+        total_episodes=None,
+        status_message="",
+        current_season=None,
+        completed_episodes=None,
+        episode_progress=None,
+    ):
         """Aktualisiere den Status thread-sicher"""
         with self._lock:  # Verwende den Lock, um Race Conditions zu vermeiden
             if title:
@@ -94,6 +109,12 @@ class DownloadStatus:
                 self.current_episode = current_episode
             if total_episodes is not None:
                 self.total_episodes = total_episodes
+            if current_season is not None:
+                self.current_season = current_season
+            if completed_episodes is not None:
+                self.completed_episodes = completed_episodes
+            if episode_progress is not None:
+                self.episode_progress = episode_progress
             if status_message:
                 self.status_message = status_message
 
@@ -105,9 +126,13 @@ class DownloadStatus:
                 'current_title': self.current_title,
                 'progress': self.progress,
                 'current_episode': self.current_episode,
+                'current_season': self.current_season,
+                'completed_episodes': self.completed_episodes,
                 'total_episodes': self.total_episodes,
+                'episode_progress': self.episode_progress,
                 'status_message': self.status_message,
-                'cancel_requested': self.cancel_requested
+                'cancel_requested': self.cancel_requested,
+                'is_paused': self.pause_requested,
             }
 
     def start_download(self):
@@ -116,22 +141,31 @@ class DownloadStatus:
             self.is_downloading = True
             self.progress = 0
             self.current_episode = 0
+            self.current_season = 0
+            self.completed_episodes = 0
+            self.total_episodes = 0
+            self.episode_progress = 0.0
+            self.pause_requested = False
             self.status_message = "Download gestartet"
 
     def finish_download(self):
         """Markiere den Download als beendet"""
-        with self._lock:
+        with self._pause_condition:
             self.is_downloading = False
             self.progress = 100
             self.cancel_requested = False
+            self.pause_requested = False
             self.status_message = "Download abgeschlossen"
+            self._pause_condition.notify_all()
 
     def request_cancel(self):
         """Fordert den Abbruch des Downloads an"""
-        with self._lock:
+        with self._pause_condition:
             if self.is_downloading:
                 self.cancel_requested = True
+                self.pause_requested = False
                 self.status_message = "Abbruch angefordert..."
+                self._pause_condition.notify_all()
                 return True
             return False
 
@@ -139,6 +173,29 @@ class DownloadStatus:
         """Prüft ob ein Abbruch angefordert wurde"""
         with self._lock:
             return self.cancel_requested
+
+    def request_pause(self):
+        with self._pause_condition:
+            if self.is_downloading and not self.cancel_requested:
+                self.pause_requested = True
+                self.status_message = "Download pausiert"
+                return True
+            return False
+
+    def resume(self):
+        with self._pause_condition:
+            if self.is_downloading and self.pause_requested:
+                self.pause_requested = False
+                self.status_message = "Download wird fortgesetzt"
+                self._pause_condition.notify_all()
+                return True
+            return False
+
+    def wait_if_paused(self) -> bool:
+        with self._pause_condition:
+            while self.pause_requested and not self.cancel_requested and self.is_downloading:
+                self._pause_condition.wait(timeout=0.5)
+            return not self.cancel_requested
 
 class RealDebrid:
     def __init__(self, api_key: str):
@@ -390,6 +447,8 @@ class StreamScraper:
         message: Optional[str] = None,
     ) -> None:
         """Invoke the currently registered progress callback if available."""
+        if isinstance(progress, (int, float)):
+            self.download_status.update(episode_progress=max(0.0, min(100.0, float(progress))))
         callback = self._current_progress_cb
         if not callback:
             return
@@ -565,6 +624,8 @@ class StreamScraper:
             full_path = os.path.join(os.path.dirname(output_path), filename)
 
             def _progress(progress, speed, eta, status):
+                if not self.download_status.wait_if_paused():
+                    return
                 message = status or "VOE-Fallback läuft"
                 self._notify_progress(progress, speed, eta, f"{title}: {message}")
 
@@ -711,6 +772,9 @@ class StreamScraper:
             logging.debug(f"Saved original VOE.sx URL for potential fallback: {original_url}")
 
         while retries < max_retries:
+            if not self.download_status.wait_if_paused():
+                logging.info(f"Download abgebrochen für: {task.title}")
+                return False
             # Check if cancel was requested
             if self.download_status.is_cancel_requested():
                 logging.info(f"Download abgebrochen für: {task.title}")
@@ -791,6 +855,8 @@ class StreamScraper:
 
                 if self._current_progress_cb:
                     def _hook(status_dict, *, _task=task):
+                        if not self.download_status.wait_if_paused():
+                            raise RuntimeError("Download abgebrochen")
                         status = status_dict.get('status')
                         if status == 'downloading':
                             total = status_dict.get('total_bytes') or status_dict.get('total_bytes_estimate') or 0
@@ -1005,6 +1071,34 @@ class StreamScraper:
 
         return sorted(episodes, key=lambda x: x["number"])
 
+    def get_series_catalog(self, url: str, respect_controls: bool = False) -> Dict[str, Any]:
+        """Load seasons and episodes without starting a download."""
+        if respect_controls and not self.download_status.wait_if_paused():
+            raise RuntimeError("Download abgebrochen")
+        response = self.make_request(url)
+        if not response:
+            raise RuntimeError("Serienseite konnte nicht geladen werden")
+
+        base_url = self.get_base_url(url)
+        soup = BeautifulSoup(response.text, 'html.parser')
+        seasons = self._extract_seasons(soup, base_url, url)
+        catalog_seasons = []
+        for season in seasons:
+            if respect_controls and not self.download_status.wait_if_paused():
+                raise RuntimeError("Download abgebrochen")
+            episodes = self._extract_episodes(season['url'], base_url)
+            catalog_seasons.append({
+                'number': season['number'],
+                'url': season['url'],
+                'episodes': episodes,
+            })
+
+        return {
+            'series_name': self._extract_series_name(url),
+            'url': url,
+            'seasons': catalog_seasons,
+        }
+
     def scrape_series(self, url: str, retry_failed: bool = True, auto_next_season: bool = True):
         """Scrape eine komplette Serie mit Unterstützung für Wiederholungsversuche und automatische nächste Staffel"""
         logging.info(f"\nStarte Serien-Scraping von: {url}")
@@ -1094,62 +1188,52 @@ class StreamScraper:
 
         logging.info("\nSerien-Scraping abgeschlossen.")
 
-    def process_series(self, url: str):
-        """Verarbeitet eine Serie mit paralleler Staffel-Verarbeitung"""
+    def process_series(self, url: str, selection: Optional[Dict[str, List[int]]] = None):
+        """Process selected episodes sequentially for deterministic queue progress."""
         try:
             logging.info(f"Starte Verarbeitung von {url}")
-            # Rufe die Startseite der Serie ab
-            response = self.make_request(url)
-            if not response:
-                return False
-
-            soup = BeautifulSoup(response.text, 'html.parser')
-            base_url = self.get_base_url(url)
-
-            # Extrahiere Seriennamen
-            series_name = self._extract_series_name(url)
+            catalog = self.get_series_catalog(url, respect_controls=True)
+            series_name = catalog['series_name']
             series_path = self._get_series_path(series_name, url)
-
-            # Erstelle Serienverzeichnis
             os.makedirs(series_path, exist_ok=True)
 
-            # Hole alle Staffeln
-            seasons = self._extract_seasons(soup, base_url, url)
+            seasons = []
+            for season in catalog['seasons']:
+                season_number = int(season['number'])
+                episodes = season.get('episodes', [])
+                if selection is not None:
+                    selected_numbers = set(selection.get(str(season_number), []))
+                    if not selected_numbers:
+                        continue
+                    episodes = [episode for episode in episodes if episode.get('number') in selected_numbers]
+                if episodes:
+                    seasons.append({**season, 'episodes': episodes})
+
             if not seasons:
-                logging.warning(f"Keine Staffeln für {series_name} gefunden")
+                logging.warning(f"Keine ausgewählten Episoden für {series_name} gefunden")
                 return False
 
-            # Sortiere Staffeln nach Nummer
             seasons.sort(key=lambda s: s.get('number', 0))
-            logging.info(f"\nGefunden: {len(seasons)} Staffeln für {series_name}")
+            total_episodes = sum(len(season['episodes']) for season in seasons)
+            progress_state = {'completed': 0, 'total': total_episodes}
+            self.download_status.update(total_episodes=total_episodes, completed_episodes=0)
+            logging.info(f"\nAusgewählt: {total_episodes} Episoden in {len(seasons)} Staffeln für {series_name}")
 
-            # Verarbeite Staffeln parallel
-            with concurrent.futures.ThreadPoolExecutor(max_workers=self.max_parallel_extractions) as executor:
-                future_to_season = {
-                    executor.submit(
-                        self._process_season,
-                        season['url'],
-                        series_name,
-                        season['number'],
-                        self._get_series_path(series_name, url)
-                    ): season['number']
-                    for season in seasons
-                }
-
-                # Verarbeite die Ergebnisse
-                completed_seasons = 0
-                new_episodes_found = False
-                for future in concurrent.futures.as_completed(future_to_season):
-                    season_num = future_to_season[future]
-                    completed_seasons += 1
-                    try:
-                        success = future.result()
-                        if success:
-                            new_episodes_found = True
-                        status = "Erfolg" if success else "Fehlgeschlagen oder keine neuen Episoden"
-                        logging.info(f"[{completed_seasons}/{len(seasons)}] Staffel {season_num}: {status}")
-                    except Exception as e:
-                        logging.error(f"[{completed_seasons}/{len(seasons)}] Staffel {season_num}: Fehler - {str(e)}")
+            for season_index, season in enumerate(seasons, 1):
+                if not self.download_status.wait_if_paused():
+                    return False
+                success = self._process_season(
+                    season['url'],
+                    series_name,
+                    season['number'],
+                    series_path,
+                    episodes=season['episodes'],
+                    progress_state=progress_state,
+                )
+                status = "Erfolg" if success else "Keine neuen Episoden"
+                logging.info(f"[{season_index}/{len(seasons)}] Staffel {season['number']}: {status}")
+                if self.download_status.is_cancel_requested():
+                    return False
 
             logging.info(f"\nAlle Staffeln von {series_name} wurden verarbeitet")
 
@@ -1169,6 +1253,7 @@ class StreamScraper:
         self,
         url: str,
         series_path: Optional[str] = None,
+        selection: Optional[Dict[str, List[int]]] = None,
         progress_cb: Optional[Callable[[Optional[float], Optional[float], Optional[float], str], None]] = None,
     ):
         """Haupteinstiegspunkt für den Download."""
@@ -1183,7 +1268,7 @@ class StreamScraper:
             self.download_status.start_download()
             self.download_status.update(status_message="Starte Download...")
             self._notify_progress(0.0, message="Starte Download...")
-            success = self.process_series(url)
+            success = self.process_series(url, selection=selection)
             if success is False:
                 raise RuntimeError("Download konnte nicht erfolgreich abgeschlossen werden")
             return success
@@ -1392,11 +1477,45 @@ class StreamScraper:
         os.makedirs(series_path, exist_ok=True)
         return series_path
 
-    def _process_season(self, url: str, series_name: str, season_num: int, series_path: str) -> bool:
-        """Verarbeitet eine einzelne Staffel. Gibt True zurück wenn neue Episoden gefunden wurden."""
+    def _begin_episode_progress(self, state, season_num: int, episode_num: int, title: str) -> bool:
+        if not self.download_status.wait_if_paused():
+            return False
+        if state is not None:
+            self.download_status.update(
+                current_season=season_num,
+                current_episode=episode_num,
+                completed_episodes=state['completed'],
+                total_episodes=state['total'],
+                episode_progress=0.0,
+                status_message=f"S{season_num:02d}E{episode_num:02d}: {title}",
+            )
+            self._notify_progress(0.0, message=f"S{season_num:02d}E{episode_num:02d}: {title}")
+        return True
+
+    def _complete_episode_progress(self, state, message: str) -> None:
+        if state is None:
+            return
+        self._notify_progress(100.0, None, 0, message)
+        state['completed'] += 1
+        self.download_status.update(
+            completed_episodes=state['completed'],
+            episode_progress=0.0,
+        )
+        self._notify_progress(0.0, None, None, message)
+
+    def _process_season(
+        self,
+        url: str,
+        series_name: str,
+        season_num: int,
+        series_path: str,
+        episodes: Optional[List[Dict]] = None,
+        progress_state: Optional[Dict[str, int]] = None,
+    ) -> bool:
+        """Process one season and preserve the selected episode order."""
         try:
-            # Verwende die erweiterte Episode-Extraktions-Methode
-            episodes = self._extract_episodes(url, self.get_base_url(url))
+            if episodes is None:
+                episodes = self._extract_episodes(url, self.get_base_url(url))
 
             if not episodes:
                 logging.warning(f"Keine Episoden in Staffel {season_num} gefunden")
@@ -1408,11 +1527,9 @@ class StreamScraper:
 
             # Hole Spracheinstellungen aus der Konfiguration
             lang_config = self.config.get("scraper", {}).get("language_preference", {})
-            prefer_german_dub = lang_config.get("prefer_german_dub", True)  # Bevorzuge deutschen Ton
             allow_german_sub = lang_config.get("allow_german_sub", True)    # Erlaube deutschen Untertitel als Fallback
 
-            # Prüfe welche Episoden neu sind
-            new_episodes = []
+            episode_actions = []
             skipped_count = 0
             skipped_no_german_count = 0
 
@@ -1438,7 +1555,7 @@ class StreamScraper:
 
                 if not should_download:
                     skipped_no_german_count += 1
-                    logging.info(f"Überspringe Episode ohne deutsche Tonspur/Untertitel: S{season_num:02d}E{episode_num:02d} - {episode_title}")
+                    episode_actions.append((episode, None, 'Keine deutsche Tonspur oder Untertitel'))
                     continue
 
                 # Erstelle Dateinamen mit Sprach-Tag
@@ -1449,6 +1566,7 @@ class StreamScraper:
                 # Überspringe bereits heruntergeladene Episoden
                 if os.path.exists(output_path):
                     skipped_count += 1
+                    episode_actions.append((episode, None, 'Bereits vorhanden'))
                     continue
 
                 # Prüfe auch, ob eine Version ohne Tag existiert
@@ -1462,36 +1580,46 @@ class StreamScraper:
                     try:
                         os.rename(output_path_no_tag, output_path)
                         skipped_count += 1
+                        episode_actions.append((episode, None, 'Vorhandene Datei umbenannt'))
                         continue
                     except Exception as e:
                         logging.error(f"Fehler beim Umbenennen: {str(e)}")
 
-                new_episodes.append((episode_num, episode_url, episode_title, output_path))
+                episode_actions.append((episode, output_path, None))
 
             total_episodes = len(episodes)
-            if not new_episodes:
-                german_dub_count = sum(1 for ep in episodes if ep.get("has_german_dub", False))
-                german_sub_count = sum(1 for ep in episodes if ep.get("has_german_sub", False))
-
-                if german_dub_count == 0 and (not allow_german_sub or german_sub_count == 0):
-                    logging.info(f"Keine Episoden mit deutscher Tonspur/Untertitel in Staffel {season_num} gefunden")
-                else:
-                    logging.info(f"Alle verfügbaren Episoden mit deutscher Tonspur/Untertitel bereits heruntergeladen")
-
-                return False
-
             logging.info(f"Gefunden: {total_episodes} Episoden in Staffel {season_num}")
             logging.info(f"Davon mit deutschem Ton: {sum(1 for ep in episodes if ep.get('has_german_dub', False))}")
             logging.info(f"Davon mit deutschem Untertitel: {sum(1 for ep in episodes if ep.get('has_german_sub', False))}")
             logging.info(f"Überspringe {skipped_count} existierende Episoden")
             logging.info(f"Überspringe {skipped_no_german_count} Episoden ohne deutsche Tonspur/Untertitel")
-            logging.info(f"Lade {len(new_episodes)} neue Episoden herunter")
+            logging.info(f"Lade {sum(1 for _, path, _ in episode_actions if path)} neue Episoden herunter")
 
-            # Erstelle Download-Tasks für neue Episoden
-            download_tasks = []
             failed_downloads = []
+            new_episodes_found = False
 
-            for episode_num, episode_url, episode_title, output_path in new_episodes:
+            for episode, output_path, skip_reason in episode_actions:
+                episode_num = episode['number']
+                episode_url = episode['url']
+                episode_title = episode['title']
+                if not self._begin_episode_progress(progress_state, season_num, episode_num, episode_title):
+                    return False
+
+                if skip_reason:
+                    logging.info(
+                        "Überspringe S%02dE%02d - %s: %s",
+                        season_num,
+                        episode_num,
+                        episode_title,
+                        skip_reason,
+                    )
+                    self._complete_episode_progress(
+                        progress_state,
+                        f"S{season_num:02d}E{episode_num:02d}: {skip_reason}",
+                    )
+                    continue
+
+                new_episodes_found = True
                 logging.info(f"Bereite vor: {os.path.basename(output_path)}")
 
                 # Hole Video-URLs als EpisodeVariant-Objekte
@@ -1499,11 +1627,17 @@ class StreamScraper:
                 if not variants:
                     logging.warning(f"Keine Video-URLs gefunden für Episode {episode_num}")
                     failed_downloads.append(f"S{season_num:02d}E{episode_num:02d} - {episode_title}")
+                    self._complete_episode_progress(
+                        progress_state,
+                        f"S{season_num:02d}E{episode_num:02d}: Keine Quelle gefunden",
+                    )
                     continue
 
                 # Versuche alle Mirrors nacheinander bis Language Guard OK sagt
                 success = False
                 for mirror_idx, variant in enumerate(variants):
+                    if not self.download_status.wait_if_paused():
+                        return False
                     logging.debug(f"Versuche Mirror {mirror_idx + 1}/{len(variants)} für {episode_title}")
                     task = DownloadTask(
                         title=episode_title,
@@ -1517,22 +1651,32 @@ class StreamScraper:
                         break
                     else:
                         logging.warning(f"Mirror {mirror_idx + 1} failed: {episode_title}")
+
+                    if self.download_status.is_cancel_requested():
+                        return False
                 
                 if not success:
                     failed_downloads.append(f"S{season_num:02d}E{episode_num:02d} - {episode_title}")
                     logging.error(f"Alle Mirrors fehlgeschlagen für {episode_title}")
+
+                result_message = 'Download abgeschlossen' if success else 'Download fehlgeschlagen'
+                self._complete_episode_progress(
+                    progress_state,
+                    f"S{season_num:02d}E{episode_num:02d}: {result_message}",
+                )
 
             # Zeige fehlgeschlagene Downloads
             if failed_downloads:
                 logging.warning("\nFehlgeschlagene Downloads:")
                 for failed in failed_downloads:
                     logging.warning(f"- {failed}")
+                raise RuntimeError(f"{len(failed_downloads)} Episode(n) konnten nicht heruntergeladen werden")
 
-            return True
+            return new_episodes_found
 
         except Exception as e:
             logging.error(f"Fehler beim Verarbeiten von Staffel {season_num}: {str(e)}")
-            return False
+            raise
 
     def get_base_url(self, url: str) -> str:
         """Extrahiert die Basis-URL aus der gegebenen URL."""

--- a/scraper.py
+++ b/scraper.py
@@ -1183,7 +1183,10 @@ class StreamScraper:
             self.download_status.start_download()
             self.download_status.update(status_message="Starte Download...")
             self._notify_progress(0.0, message="Starte Download...")
-            self.process_series(url)
+            success = self.process_series(url)
+            if success is False:
+                raise RuntimeError("Download konnte nicht erfolgreich abgeschlossen werden")
+            return success
         except Exception as e:
             error = e
             self.download_status.update(status_message=f"Fehler: {str(e)}")

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -100,6 +100,13 @@ body {
 .search-result-item { margin-bottom: .55rem; color: var(--text); background: var(--surface-2); border: 1px solid var(--border) !important; border-radius: 12px !important; transition: transform .2s, border-color .2s, background .2s; }
 .search-result-item:hover { color: var(--text); background: var(--surface-3); border-color: rgba(124,92,255,.55) !important; transform: translateY(-2px); }
 .search-result-item .badge { margin-left: 8px; }
+.queue-job { color: var(--text); background: transparent; border-color: var(--border); }
+.queue-job__meta { color: var(--muted); font-size: .78rem; }
+.queue-job__status { font-size: .72rem; font-weight: 700; letter-spacing: .04em; text-transform: uppercase; }
+.queue-job__actions { display: flex; justify-content: flex-end; margin-top: .65rem; }
+.queue-job--failed .queue-job__status { color: var(--danger); }
+.queue-job--completed .queue-job__status { color: var(--accent-2); }
+.queue-job--cancelled .queue-job__status { color: var(--muted); }
 #search-input { border-top-right-radius: 0; border-bottom-right-radius: 0; }
 #search-type { border-top-left-radius: 0; border-bottom-left-radius: 0; }
 .alert { color: var(--text); background: var(--surface-3); border-color: var(--border); border-radius: 12px; }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -107,12 +107,21 @@ body {
 .queue-job--failed .queue-job__status { color: var(--danger); }
 .queue-job--completed .queue-job__status { color: var(--accent-2); }
 .queue-job--cancelled .queue-job__status { color: var(--muted); }
+.queue-job--paused .queue-job__status { color: #f2c14e; }
 #search-input { border-top-right-radius: 0; border-bottom-right-radius: 0; }
 #search-type { border-top-left-radius: 0; border-bottom-left-radius: 0; }
 .alert { color: var(--text); background: var(--surface-3); border-color: var(--border); border-radius: 12px; }
 
 .progress { height: 12px; background: var(--surface-3); border-radius: 99px; }
 .progress-bar { background: linear-gradient(90deg, var(--accent), var(--accent-2)); transition: width .3s ease; }
+.progress-bar--episode { background: linear-gradient(90deg, #24d3b5, #43a5ff); }
+.modal-content { color: var(--text); background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); box-shadow: var(--shadow); }
+.modal-header, .modal-footer { border-color: var(--border); }
+.episode-season { margin-bottom: .85rem; overflow: hidden; background: var(--surface-2); border: 1px solid var(--border); border-radius: 13px; }
+.episode-season__header { display: flex; align-items: center; justify-content: space-between; gap: 1rem; padding: .85rem 1rem; background: rgba(255,255,255,.025); border-bottom: 1px solid var(--border); }
+.episode-season__episodes { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: .55rem; padding: .85rem; }
+.episode-choice { display: flex; gap: .6rem; align-items: flex-start; min-height: 58px; padding: .65rem; background: var(--surface-3); border-radius: 10px; }
+.episode-choice small { display: block; color: var(--muted); }
 .global-download { position: relative; z-index: 1040; display: flex; flex-wrap: wrap; gap: 1rem; align-items: center; justify-content: space-between; width: 100%; padding: .75rem max(1rem, calc((100% - 1140px) / 2)); color: #fff; background: linear-gradient(90deg, #32247c, #174c4c); border-bottom: 1px solid rgba(255,255,255,.12); }
 .global-download.hidden { display: none; }
 .global-download__info { display: flex; flex-direction: column; gap: .2rem; min-width: 180px; }
@@ -121,6 +130,7 @@ body {
 .global-download__progress > #statusProgress { display: flex; height: 100%; align-items: center; justify-content: center; overflow: visible; color: transparent; font-size: .7rem; font-weight: 700; background: var(--accent-2); transition: width .3s ease; }
 .global-download__meta { display: flex; align-items: center; gap: .75rem; }
 #cancelDownloadBtn { display: none; padding: .35rem .75rem; color: #fff; background: var(--danger); border: 0; border-radius: 8px; }
+#pauseDownloadBtn { display: none; padding: .35rem .75rem; color: #fff; background: rgba(255,255,255,.14); border: 1px solid rgba(255,255,255,.18); border-radius: 8px; }
 .downloading #cancelDownloadBtn { display: inline-block; }
 
 @media (max-width: 991.98px) {

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -34,6 +34,15 @@ const refreshLibraryBtn = document.getElementById('refresh-library-btn');
 const downloadQueueList = document.getElementById('download-queue-list');
 const downloadQueueCount = document.getElementById('download-queue-count');
 const downloadHistoryList = document.getElementById('download-history-list');
+const episodeSelectionModalElement = document.getElementById('episode-selection-modal');
+const episodeSelectionLoading = document.getElementById('episode-selection-loading');
+const episodeSelectionError = document.getElementById('episode-selection-error');
+const episodeSelectionContent = document.getElementById('episode-selection-content');
+const episodeSelectionTitle = document.getElementById('episode-selection-title');
+const episodeSelectionCount = document.getElementById('episode-selection-count');
+const selectAllEpisodesBtn = document.getElementById('select-all-episodes-btn');
+const selectNoEpisodesBtn = document.getElementById('select-no-episodes-btn');
+const queueSelectedEpisodesBtn = document.getElementById('queue-selected-episodes-btn');
 
 // Status elements
 const statusViews = [
@@ -49,6 +58,10 @@ const statusViews = [
         progressDisplayStyle: 'block',
         episode: document.getElementById('statusEpisode'),
         totalEpisodes: document.getElementById('statusTotalEpisodes'),
+        currentEpisode: null,
+        episodeProgressBar: null,
+        episodeProgressWrapper: null,
+        pauseButton: document.getElementById('pauseDownloadBtn'),
         cancelButton: document.getElementById('cancelDownloadBtn'),
         hideWhenInactive: true,
     },
@@ -61,18 +74,28 @@ const statusViews = [
         progressDisplayStyle: 'block',
         episode: document.getElementById('status-card-episode'),
         totalEpisodes: document.getElementById('status-card-total-episodes'),
+        currentEpisode: document.getElementById('status-card-current-episode'),
+        episodeProgressBar: document.getElementById('status-card-episode-progress'),
+        episodeProgressWrapper: document.getElementById('status-card-episode-progress-wrapper'),
+        pauseButton: document.getElementById('pause-download-btn'),
         cancelButton: document.getElementById('cancel-download-btn'),
         hideWhenInactive: false,
     },
-].filter(view => view.container || view.title || view.message || view.progressBar || view.cancelButton);
+].filter(view => view.container || view.title || view.message || view.progressBar || view.cancelButton || view.pauseButton);
 
 const cancelButtons = Array.from(new Set(statusViews
     .map(view => view.cancelButton)
+    .filter((btn) => Boolean(btn))));
+const pauseButtons = Array.from(new Set(statusViews
+    .map(view => view.pauseButton)
     .filter((btn) => Boolean(btn))));
 
 // Variables
 let searchTimeout = null;
 let isDownloading = false;
+let activeJobId = null;
+let isPaused = false;
+let pendingSelection = null;
 
 // Event Listeners
 document.addEventListener('DOMContentLoaded', () => {
@@ -138,6 +161,19 @@ document.addEventListener('DOMContentLoaded', () => {
     cancelButtons.forEach((btn) => {
         btn.addEventListener('click', cancelDownload);
     });
+    pauseButtons.forEach((btn) => {
+        btn.addEventListener('click', togglePauseDownload);
+    });
+
+    if (selectAllEpisodesBtn) {
+        selectAllEpisodesBtn.addEventListener('click', () => setAllEpisodeChoices(true));
+    }
+    if (selectNoEpisodesBtn) {
+        selectNoEpisodesBtn.addEventListener('click', () => setAllEpisodeChoices(false));
+    }
+    if (queueSelectedEpisodesBtn) {
+        queueSelectedEpisodesBtn.addEventListener('click', queueSelectedEpisodes);
+    }
 
     // Check download status on page load
     checkDownloadStatus();
@@ -442,12 +478,157 @@ function showAniworldMessage(message, level = 'info') {
  * Start download
  */
 function startDownload(url) {
+    if (!episodeSelectionModalElement || !window.bootstrap) {
+        alert('Die Episodenauswahl konnte nicht geöffnet werden.');
+        return;
+    }
+
+    pendingSelection = { url, catalog: null };
+    episodeSelectionLoading.classList.remove('d-none');
+    episodeSelectionError.classList.add('d-none');
+    episodeSelectionContent.classList.add('d-none');
+    episodeSelectionContent.innerHTML = '';
+    episodeSelectionTitle.textContent = 'Staffeln und Episoden wählen';
+    queueSelectedEpisodesBtn.disabled = true;
+    updateEpisodeSelectionCount();
+    bootstrap.Modal.getOrCreateInstance(episodeSelectionModalElement).show();
+
+    fetch('/api/download/catalog', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url }),
+    })
+        .then((response) => response.json().then((data) => ({ response, data })))
+        .then(({ response, data }) => {
+            if (!response.ok || !data.ok) {
+                throw new Error(data.error || 'Episoden konnten nicht geladen werden');
+            }
+            pendingSelection.catalog = data.data;
+            renderEpisodeSelection(data.data);
+        })
+        .catch((error) => {
+            console.error('Episode catalog failed:', error);
+            episodeSelectionLoading.classList.add('d-none');
+            episodeSelectionError.textContent = error.message;
+            episodeSelectionError.classList.remove('d-none');
+        });
+}
+
+function renderEpisodeSelection(catalog) {
+    episodeSelectionLoading.classList.add('d-none');
+    episodeSelectionContent.classList.remove('d-none');
+    episodeSelectionTitle.textContent = catalog.series_name || 'Staffeln und Episoden wählen';
+    episodeSelectionContent.innerHTML = '';
+
+    (catalog.seasons || []).forEach((season) => {
+        const section = document.createElement('section');
+        section.className = 'episode-season';
+
+        const header = document.createElement('div');
+        header.className = 'episode-season__header';
+        const title = document.createElement('strong');
+        title.textContent = `Staffel ${season.number}`;
+        const seasonToggle = document.createElement('input');
+        seasonToggle.type = 'checkbox';
+        seasonToggle.className = 'form-check-input';
+        seasonToggle.checked = true;
+        seasonToggle.setAttribute('aria-label', `Staffel ${season.number} auswählen`);
+        header.append(title, seasonToggle);
+
+        const choices = document.createElement('div');
+        choices.className = 'episode-season__episodes';
+        (season.episodes || []).forEach((episode) => {
+            const label = document.createElement('label');
+            label.className = 'episode-choice';
+            const checkbox = document.createElement('input');
+            checkbox.type = 'checkbox';
+            checkbox.className = 'form-check-input episode-choice-input';
+            checkbox.checked = true;
+            checkbox.dataset.season = String(season.number);
+            checkbox.dataset.episode = String(episode.number);
+
+            const text = document.createElement('span');
+            const name = document.createElement('strong');
+            name.textContent = `E${String(episode.number).padStart(2, '0')} · ${episode.title || 'Ohne Titel'}`;
+            const language = document.createElement('small');
+            language.textContent = episode.has_german_dub
+                ? 'Deutsch'
+                : (episode.has_german_sub ? 'Deutsche Untertitel' : 'Keine deutsche Spur erkannt');
+            text.append(name, language);
+            label.append(checkbox, text);
+            choices.appendChild(label);
+        });
+
+        seasonToggle.addEventListener('change', () => {
+            choices.querySelectorAll('.episode-choice-input').forEach((checkbox) => {
+                checkbox.checked = seasonToggle.checked;
+            });
+            updateEpisodeSelectionCount();
+        });
+        choices.addEventListener('change', () => {
+            const episodeChoices = Array.from(choices.querySelectorAll('.episode-choice-input'));
+            seasonToggle.checked = episodeChoices.length > 0 && episodeChoices.every((choice) => choice.checked);
+            seasonToggle.indeterminate = episodeChoices.some((choice) => choice.checked) && !seasonToggle.checked;
+            updateEpisodeSelectionCount();
+        });
+
+        section.append(header, choices);
+        episodeSelectionContent.appendChild(section);
+    });
+    updateEpisodeSelectionCount();
+}
+
+function setAllEpisodeChoices(checked) {
+    if (!episodeSelectionContent) {
+        return;
+    }
+    episodeSelectionContent.querySelectorAll('input[type="checkbox"]').forEach((checkbox) => {
+        checkbox.checked = checked;
+        checkbox.indeterminate = false;
+    });
+    updateEpisodeSelectionCount();
+}
+
+function updateEpisodeSelectionCount() {
+    const selected = episodeSelectionContent
+        ? episodeSelectionContent.querySelectorAll('.episode-choice-input:checked').length
+        : 0;
+    if (episodeSelectionCount) {
+        episodeSelectionCount.textContent = `${selected} ausgewählt`;
+    }
+    if (queueSelectedEpisodesBtn) {
+        queueSelectedEpisodesBtn.disabled = selected === 0 || !pendingSelection || !pendingSelection.catalog;
+    }
+}
+
+function queueSelectedEpisodes() {
+    if (!pendingSelection || !pendingSelection.catalog) {
+        return;
+    }
+    const selection = {};
+    episodeSelectionContent.querySelectorAll('.episode-choice-input:checked').forEach((checkbox) => {
+        const season = checkbox.dataset.season;
+        if (!selection[season]) {
+            selection[season] = [];
+        }
+        selection[season].push(Number(checkbox.dataset.episode));
+    });
+    if (Object.keys(selection).length === 0) {
+        return;
+    }
+
+    queueSelectedEpisodesBtn.disabled = true;
+    queueSelectedEpisodesBtn.textContent = 'Wird eingereiht…';
     fetch('/download', {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json'
         },
-        body: JSON.stringify({ url })
+        body: JSON.stringify({
+            url: pendingSelection.url,
+            series_name: pendingSelection.catalog.series_name,
+            selection,
+        })
     })
     .then(response => {
         if (!response.ok) {
@@ -459,6 +640,7 @@ function startDownload(url) {
     })
     .then(data => {
         console.log('Download queued:', data);
+        bootstrap.Modal.getOrCreateInstance(episodeSelectionModalElement).hide();
         // Switch to status tab
         document.getElementById('status-tab').click();
         checkDownloadStatus();
@@ -466,6 +648,10 @@ function startDownload(url) {
     .catch(error => {
         console.error('Error starting download:', error);
         alert('Fehler beim Starten des Downloads: ' + error.message);
+    })
+    .finally(() => {
+        queueSelectedEpisodesBtn.textContent = 'Zur Queue hinzufügen';
+        updateEpisodeSelectionCount();
     });
 }
 
@@ -590,11 +776,14 @@ function updateStatusDisplay(payload) {
 
     let activeJob = null;
     let active = false;
+    let authoritativeStatus = false;
 
     if (payload) {
         if (payload.ok && payload.data) {
+            authoritativeStatus = true;
             active = Boolean(payload.data.is_downloading);
             activeJob = payload.data.active || null;
+            isPaused = Boolean(payload.data.is_paused || (activeJob && activeJob.status === 'paused'));
             renderDownloadJobs(payload.data.queue || [], payload.data.history || []);
         } else if (Object.prototype.hasOwnProperty.call(payload, 'job') || Object.prototype.hasOwnProperty.call(payload, 'is_downloading')) {
             active = Boolean(payload.is_downloading);
@@ -609,9 +798,17 @@ function updateStatusDisplay(payload) {
                 message: payload.status_message,
                 series_name: payload.current_title,
                 current_episode: payload.current_episode,
+                current_season: payload.current_season,
+                completed_episodes: payload.completed_episodes,
                 total_episodes: payload.total_episodes,
+                episode_progress: payload.episode_progress,
+                is_paused: payload.is_paused,
             };
         }
+    }
+
+    if (authoritativeStatus) {
+        activeJobId = activeJob && activeJob.id ? activeJob.id : null;
     }
 
     const firstMessageView = statusViews.find((view) => view.message);
@@ -628,6 +825,12 @@ function updateStatusDisplay(payload) {
         const pct = typeof activeJob.progress === 'number' && !Number.isNaN(activeJob.progress)
             ? Math.max(0, Math.min(100, activeJob.progress))
             : null;
+        const episodePct = typeof activeJob.episode_progress === 'number' && !Number.isNaN(activeJob.episode_progress)
+            ? Math.max(0, Math.min(100, activeJob.episode_progress))
+            : null;
+        const completedEpisodes = Number.isInteger(activeJob.completed_episodes)
+            ? activeJob.completed_episodes
+            : 0;
 
         statusViews.forEach((view) => {
             const {
@@ -639,6 +842,10 @@ function updateStatusDisplay(payload) {
                 progressDisplayStyle,
                 episode,
                 totalEpisodes,
+                currentEpisode,
+                episodeProgressBar,
+                episodeProgressWrapper,
+                pauseButton,
                 cancelButton,
                 hideWhenInactive,
             } = view;
@@ -665,14 +872,36 @@ function updateStatusDisplay(payload) {
             if (progressBar && pct !== null) {
                 progressBar.style.width = `${pct}%`;
                 progressBar.textContent = `${Math.round(pct)}%`;
+                progressBar.setAttribute('aria-valuenow', String(Math.round(pct)));
+            }
+
+            if (episodeProgressWrapper) {
+                episodeProgressWrapper.style.display = 'block';
+            }
+
+            if (episodeProgressBar && episodePct !== null) {
+                episodeProgressBar.style.width = `${episodePct}%`;
+                episodeProgressBar.textContent = `${Math.round(episodePct)}%`;
+                episodeProgressBar.setAttribute('aria-valuenow', String(Math.round(episodePct)));
             }
 
             if (episode) {
-                episode.textContent = activeJob.current_episode || '1';
+                episode.textContent = String(completedEpisodes);
             }
 
             if (totalEpisodes) {
                 totalEpisodes.textContent = activeJob.total_episodes || '?';
+            }
+
+            if (currentEpisode) {
+                currentEpisode.textContent = activeJob.current_season && activeJob.current_episode
+                    ? `S${String(activeJob.current_season).padStart(2, '0')}E${String(activeJob.current_episode).padStart(2, '0')}`
+                    : '-';
+            }
+
+            if (pauseButton) {
+                pauseButton.style.display = 'inline-block';
+                pauseButton.textContent = isPaused ? 'Fortsetzen' : 'Pausieren';
             }
 
             if (cancelButton) {
@@ -688,6 +917,9 @@ function updateStatusDisplay(payload) {
                 progressWrapper,
                 episode,
                 totalEpisodes,
+                currentEpisode,
+                episodeProgressWrapper,
+                pauseButton,
                 cancelButton,
                 hideWhenInactive,
             } = view;
@@ -719,10 +951,24 @@ function updateStatusDisplay(payload) {
                 totalEpisodes.textContent = '-';
             }
 
+            if (currentEpisode) {
+                currentEpisode.textContent = '-';
+            }
+
+            if (episodeProgressWrapper) {
+                episodeProgressWrapper.style.display = 'none';
+            }
+
+            if (pauseButton) {
+                pauseButton.style.display = 'none';
+            }
+
             if (cancelButton) {
                 cancelButton.style.display = 'none';
             }
         });
+        activeJobId = null;
+        isPaused = false;
     }
 }
 
@@ -1212,6 +1458,25 @@ function filterLibraryContent(query, type) {
         const existingMsg = libraryContent.querySelector('.alert');
         if (existingMsg) existingMsg.remove();
     }
+}
+
+function togglePauseDownload() {
+    if (!activeJobId) {
+        return;
+    }
+    const action = isPaused ? 'resume' : 'pause';
+    fetch(`/api/downloads/${activeJobId}/${action}`, { method: 'POST' })
+        .then((response) => response.json().then((data) => ({ response, data })))
+        .then(({ response, data }) => {
+            if (!response.ok) {
+                throw new Error(data.message || data.error || 'Aktion fehlgeschlagen');
+            }
+            checkDownloadStatus();
+        })
+        .catch((error) => {
+            console.error(`Queue action ${action} failed:`, error);
+            alert(error.message);
+        });
 }
 
 /**

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -31,6 +31,9 @@ const librarySearch = document.getElementById('library-search');
 const libraryType = document.getElementById('library-type');
 const libraryContent = document.getElementById('library-content');
 const refreshLibraryBtn = document.getElementById('refresh-library-btn');
+const downloadQueueList = document.getElementById('download-queue-list');
+const downloadQueueCount = document.getElementById('download-queue-count');
+const downloadHistoryList = document.getElementById('download-history-list');
 
 // Status elements
 const statusViews = [
@@ -439,11 +442,6 @@ function showAniworldMessage(message, level = 'info') {
  * Start download
  */
 function startDownload(url) {
-    if (isDownloading) {
-        alert('Es läuft bereits ein Download!');
-        return;
-    }
-
     fetch('/download', {
         method: 'POST',
         headers: {
@@ -460,9 +458,10 @@ function startDownload(url) {
         return response.json();
     })
     .then(data => {
-        console.log('Download started:', data);
+        console.log('Download queued:', data);
         // Switch to status tab
         document.getElementById('status-tab').click();
+        checkDownloadStatus();
     })
     .catch(error => {
         console.error('Error starting download:', error);
@@ -596,6 +595,7 @@ function updateStatusDisplay(payload) {
         if (payload.ok && payload.data) {
             active = Boolean(payload.data.is_downloading);
             activeJob = payload.data.active || null;
+            renderDownloadJobs(payload.data.queue || [], payload.data.history || []);
         } else if (Object.prototype.hasOwnProperty.call(payload, 'job') || Object.prototype.hasOwnProperty.call(payload, 'is_downloading')) {
             active = Boolean(payload.is_downloading);
             activeJob = payload.job || null;
@@ -724,6 +724,85 @@ function updateStatusDisplay(payload) {
             }
         });
     }
+}
+
+function renderDownloadJobs(queue, history) {
+    if (downloadQueueCount) {
+        downloadQueueCount.textContent = String(queue.length);
+    }
+    renderJobList(downloadQueueList, queue, 'Keine wartenden Downloads');
+    renderJobList(downloadHistoryList, history, 'Noch kein Verlauf');
+}
+
+function renderJobList(container, jobs, emptyMessage) {
+    if (!container) {
+        return;
+    }
+
+    container.innerHTML = '';
+    if (!jobs.length) {
+        const empty = document.createElement('div');
+        empty.className = 'list-group-item queue-job text-muted';
+        empty.textContent = emptyMessage;
+        container.appendChild(empty);
+        return;
+    }
+
+    jobs.forEach((job) => {
+        const item = document.createElement('div');
+        item.className = `list-group-item queue-job queue-job--${job.status || 'pending'}`;
+
+        const row = document.createElement('div');
+        row.className = 'd-flex align-items-start justify-content-between gap-3';
+
+        const details = document.createElement('div');
+        const title = document.createElement('strong');
+        title.textContent = job.series_name || `Download #${job.id}`;
+        const message = document.createElement('div');
+        message.className = 'queue-job__meta';
+        message.textContent = job.error || job.message || job.url;
+        details.append(title, message);
+
+        const status = document.createElement('span');
+        status.className = 'queue-job__status';
+        status.textContent = job.status || 'pending';
+        row.append(details, status);
+        item.appendChild(row);
+
+        if (job.status === 'pending' || job.status === 'failed' || job.status === 'cancelled') {
+            const actions = document.createElement('div');
+            actions.className = 'queue-job__actions';
+
+            const action = document.createElement('button');
+            action.type = 'button';
+            action.className = 'btn btn-sm btn-outline-secondary';
+            if (job.status === 'pending') {
+                action.textContent = 'Abbrechen';
+                action.addEventListener('click', () => mutateDownloadJob(job.id, 'cancel'));
+            } else {
+                action.textContent = 'Wiederholen';
+                action.addEventListener('click', () => mutateDownloadJob(job.id, 'retry'));
+            }
+            actions.appendChild(action);
+            item.appendChild(actions);
+        }
+        container.appendChild(item);
+    });
+}
+
+function mutateDownloadJob(jobId, action) {
+    fetch(`/api/downloads/${jobId}/${action}`, { method: 'POST' })
+        .then((response) => response.json().then((data) => ({ response, data })))
+        .then(({ response, data }) => {
+            if (!response.ok) {
+                throw new Error(data.message || data.error || 'Aktion fehlgeschlagen');
+            }
+            checkDownloadStatus();
+        })
+        .catch((error) => {
+            console.error(`Queue action ${action} failed:`, error);
+            alert(error.message);
+        });
 }
 
 /**

--- a/templates/base.html
+++ b/templates/base.html
@@ -20,6 +20,7 @@
         </div>
         <div class="global-download__meta">
             <span>Episoden: <span id="statusEpisode">-</span>/<span id="statusTotalEpisodes">-</span></span>
+            <button id="pauseDownloadBtn" type="button" style="display: none;">Pausieren</button>
             <button id="cancelDownloadBtn" type="button" style="display: none;">Abbrechen</button>
         </div>
     </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -102,6 +102,27 @@
                     </div>
                 </div>
             </div>
+            <div class="row g-3">
+                <div class="col-lg-6">
+                    <div class="card h-100">
+                        <div class="card-header d-flex align-items-center justify-content-between">
+                            <span>Warteschlange</span>
+                            <span id="download-queue-count" class="badge bg-primary">0</span>
+                        </div>
+                        <div id="download-queue-list" class="list-group list-group-flush">
+                            <div class="list-group-item text-muted">Keine wartenden Downloads</div>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-lg-6">
+                    <div class="card h-100">
+                        <div class="card-header">Letzte Downloads</div>
+                        <div id="download-history-list" class="list-group list-group-flush">
+                            <div class="list-group-item text-muted">Noch kein Verlauf</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </div>
 
         <!-- Settings Tab -->

--- a/templates/index.html
+++ b/templates/index.html
@@ -91,14 +91,22 @@
                     <div class="progress mb-3" id="status-card-progress-wrapper" style="display: none;">
                         <div id="status-card-progress" class="progress-bar" role="progressbar" style="width: 0%;" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">0%</div>
                     </div>
+                    <small class="text-muted d-block mb-1">Aktuelle Episode</small>
+                    <div class="progress mb-3" id="status-card-episode-progress-wrapper" style="display: none;">
+                        <div id="status-card-episode-progress" class="progress-bar progress-bar--episode" role="progressbar" style="width: 0%;" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">0%</div>
+                    </div>
                     <p class="card-text">
                         <small class="text-muted">
-                            Episode: <span id="status-card-episode">-</span> / <span id="status-card-total-episodes">-</span>
+                            Verarbeitet: <span id="status-card-episode">-</span> / <span id="status-card-total-episodes">-</span>
+                            · Aktuell: <span id="status-card-current-episode">-</span>
                         </small>
                     </p>
-                    <div class="d-flex justify-content-between">
+                    <div class="d-flex justify-content-between gap-2 flex-wrap">
                         <button id="reset-session-btn" class="btn btn-secondary">Session zurücksetzen</button>
-                        <button id="cancel-download-btn" class="btn btn-danger" style="display: none;">Download abbrechen</button>
+                        <div class="d-flex gap-2">
+                            <button id="pause-download-btn" class="btn btn-secondary" style="display: none;">Pausieren</button>
+                            <button id="cancel-download-btn" class="btn btn-danger" style="display: none;">Download abbrechen</button>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -211,6 +219,35 @@
 
             <div id="library-content">
                 <div class="alert alert-info">Lade Mediathek...</div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="episode-selection-modal" tabindex="-1" aria-labelledby="episode-selection-title" aria-hidden="true">
+    <div class="modal-dialog modal-lg modal-dialog-scrollable">
+        <div class="modal-content">
+            <div class="modal-header">
+                <div>
+                    <span class="eyebrow">Download vorbereiten</span>
+                    <h2 class="modal-title fs-5" id="episode-selection-title">Staffeln und Episoden wählen</h2>
+                </div>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Schließen"></button>
+            </div>
+            <div class="modal-body">
+                <div id="episode-selection-loading" class="text-muted">Staffeln und Episoden werden geladen…</div>
+                <div id="episode-selection-error" class="alert alert-danger d-none"></div>
+                <div id="episode-selection-content" class="d-none"></div>
+            </div>
+            <div class="modal-footer justify-content-between">
+                <div class="d-flex gap-2">
+                    <button type="button" id="select-all-episodes-btn" class="btn btn-secondary">Alle</button>
+                    <button type="button" id="select-no-episodes-btn" class="btn btn-secondary">Keine</button>
+                </div>
+                <div class="d-flex align-items-center gap-3">
+                    <span id="episode-selection-count" class="text-muted">0 ausgewählt</span>
+                    <button type="button" id="queue-selected-episodes-btn" class="btn btn-primary" disabled>Zur Queue hinzufügen</button>
+                </div>
             </div>
         </div>
     </div>

--- a/tests/test_download_queue.py
+++ b/tests/test_download_queue.py
@@ -18,6 +18,9 @@ def test_persistent_queue_transitions(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv('SCAP_STREAMS_DB_PATH', str(tmp_path / 'queue.db'))
     app_module = importlib.import_module('app')
 
+    with app_module.app.app_context():
+        assert app_module.ensure_download_job_schema() == 0
+
     monkeypatch.setattr(
         app_module,
         'determine_series_target_path',
@@ -27,16 +30,28 @@ def test_persistent_queue_transitions(monkeypatch, tmp_path) -> None:
     first_started = threading.Event()
     release_first = threading.Event()
     calls = []
+    received_selections = []
 
-    def fake_download(url, series_path=None, progress_cb=None):
+    def fake_download(url, series_path=None, selection=None, progress_cb=None):
         calls.append(url)
+        received_selections.append(selection)
         app_module.scraper.download_status.start_download()
         try:
+            app_module.scraper.download_status.update(
+                current_season=1,
+                current_episode=2,
+                completed_episodes=1,
+                total_episodes=3,
+                episode_progress=50.0,
+            )
             if progress_cb:
                 progress_cb(50.0, None, None, 'Halb fertig')
             if url.endswith('/first'):
                 first_started.set()
-                assert release_first.wait(timeout=2.0)
+                deadline = time.monotonic() + 2.0
+                while not release_first.wait(timeout=0.02):
+                    assert time.monotonic() < deadline
+                    assert app_module.scraper.download_status.wait_if_paused()
             if url.endswith('/fails'):
                 raise RuntimeError('simulierter Fehler')
             return True
@@ -46,18 +61,52 @@ def test_persistent_queue_transitions(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(app_module.scraper, 'start_download', fake_download)
     client = app_module.app.test_client()
 
+    catalog_data = {
+        'series_name': 'Testserie',
+        'url': 'https://example.test/first',
+        'seasons': [{
+            'number': 1,
+            'url': 'https://example.test/first/season-1',
+            'episodes': [{'number': 1, 'title': 'Pilot', 'url': 'https://example.test/e1'}],
+        }],
+    }
+    monkeypatch.setattr(app_module.scraper, 'get_series_catalog', lambda url: catalog_data)
+    catalog = client.post('/api/download/catalog', json={'url': 'https://example.test/first'})
+    assert catalog.status_code == 200
+    assert catalog.get_json()['data'] == catalog_data
+
+    first_selection = {'1': [1, 2, 3]}
     first = client.post('/download', json={
         'url': 'https://example.test/first',
         'series_name': 'Erster Auftrag',
+        'selection': first_selection,
     })
     assert first.status_code == 202
+    assert first.get_json()['job']['selection'] == first_selection
+    assert first.get_json()['job']['selected_episode_count'] == 3
     assert first_started.wait(timeout=2.0)
 
     active = _wait_for(
         lambda: client.get('/api/downloads/status').get_json()['data']['active']
     )
     assert active['progress'] == 50.0
+    assert active['episode_progress'] == 50.0
+    assert active['current_season'] == 1
+    assert active['current_episode'] == 2
+    assert active['completed_episodes'] == 1
+    assert active['total_episodes'] == 3
     assert active['message'] == 'Halb fertig'
+
+    pause = client.post(f"/api/downloads/{first.get_json()['job']['id']}/pause")
+    assert pause.status_code == 200
+    assert pause.get_json()['job']['status'] == 'paused'
+    paused = client.get('/api/downloads/status').get_json()['data']
+    assert paused['is_paused'] is True
+    assert paused['active']['status'] == 'paused'
+
+    resume = client.post(f"/api/downloads/{first.get_json()['job']['id']}/resume")
+    assert resume.status_code == 202
+    assert resume.get_json()['job']['status'] == 'downloading'
 
     cancelled = client.post('/download', json={
         'url': 'https://example.test/cancelled',
@@ -92,11 +141,12 @@ def test_persistent_queue_transitions(monkeypatch, tmp_path) -> None:
     failed_job = next(job for job in payload['history'] if job['id'] == failed_id)
     assert failed_job['error'] == 'simulierter Fehler'
     assert calls == ['https://example.test/first', 'https://example.test/fails']
+    assert received_selections[0] == first_selection
 
     monkeypatch.setattr(
         app_module.scraper,
         'start_download',
-        lambda url, series_path=None, progress_cb=None: True,
+        lambda url, series_path=None, selection=None, progress_cb=None: True,
     )
     retry = client.post(f'/api/downloads/{failed_id}/retry')
     assert retry.status_code == 202
@@ -118,8 +168,30 @@ def test_persistent_queue_transitions(monkeypatch, tmp_path) -> None:
             message='Lief beim Neustart',
         )
         app_module.db.session.add(interrupted)
+        paused_job = app_module.DownloadJob(
+            url='https://example.test/paused',
+            status='paused',
+            progress=41.0,
+            message='Bewusst pausiert',
+        )
+        app_module.db.session.add(paused_job)
         app_module.db.session.commit()
         assert app_module.recover_interrupted_download_jobs() == 1
         assert interrupted.status == 'pending'
         assert interrupted.progress == 0.0
         assert interrupted.started_at is None
+        assert paused_job.status == 'paused'
+        assert paused_job.progress == 41.0
+
+        app_module._queue_wakeup.set()
+        time.sleep(0.05)
+        app_module.db.session.expire_all()
+        assert app_module.db.session.get(app_module.DownloadJob, interrupted.id).status == 'pending'
+
+        cancel_pending = client.post(f'/api/downloads/{interrupted.id}/cancel')
+        assert cancel_pending.status_code == 200
+        assert cancel_pending.get_json()['job']['status'] == 'cancelled'
+
+        cancel_paused = client.post(f'/api/downloads/{paused_job.id}/cancel')
+        assert cancel_paused.status_code == 200
+        assert cancel_paused.get_json()['job']['status'] == 'cancelled'

--- a/tests/test_download_queue.py
+++ b/tests/test_download_queue.py
@@ -1,0 +1,125 @@
+import importlib
+import threading
+import time
+
+
+def _wait_for(predicate, timeout=3.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        value = predicate()
+        if value:
+            return value
+        time.sleep(0.02)
+    raise AssertionError('Queue-Zustand wurde nicht rechtzeitig erreicht')
+
+
+def test_persistent_queue_transitions(monkeypatch, tmp_path) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv('SCAP_STREAMS_DB_PATH', str(tmp_path / 'queue.db'))
+    app_module = importlib.import_module('app')
+
+    monkeypatch.setattr(
+        app_module,
+        'determine_series_target_path',
+        lambda url, series_id=None, library_id=None: (None, None),
+    )
+
+    first_started = threading.Event()
+    release_first = threading.Event()
+    calls = []
+
+    def fake_download(url, series_path=None, progress_cb=None):
+        calls.append(url)
+        app_module.scraper.download_status.start_download()
+        try:
+            if progress_cb:
+                progress_cb(50.0, None, None, 'Halb fertig')
+            if url.endswith('/first'):
+                first_started.set()
+                assert release_first.wait(timeout=2.0)
+            if url.endswith('/fails'):
+                raise RuntimeError('simulierter Fehler')
+            return True
+        finally:
+            app_module.scraper.download_status.finish_download()
+
+    monkeypatch.setattr(app_module.scraper, 'start_download', fake_download)
+    client = app_module.app.test_client()
+
+    first = client.post('/download', json={
+        'url': 'https://example.test/first',
+        'series_name': 'Erster Auftrag',
+    })
+    assert first.status_code == 202
+    assert first_started.wait(timeout=2.0)
+
+    active = _wait_for(
+        lambda: client.get('/api/downloads/status').get_json()['data']['active']
+    )
+    assert active['progress'] == 50.0
+    assert active['message'] == 'Halb fertig'
+
+    cancelled = client.post('/download', json={
+        'url': 'https://example.test/cancelled',
+        'series_name': 'Abgebrochener Auftrag',
+    })
+    failed = client.post('/download', json={
+        'url': 'https://example.test/fails',
+        'series_name': 'Fehlgeschlagener Auftrag',
+    })
+    assert cancelled.status_code == 202
+    assert failed.status_code == 202
+
+    cancelled_id = cancelled.get_json()['job']['id']
+    failed_id = failed.get_json()['job']['id']
+    cancel_response = client.post(f'/api/downloads/{cancelled_id}/cancel')
+    assert cancel_response.status_code == 200
+    assert cancel_response.get_json()['job']['status'] == 'cancelled'
+
+    release_first.set()
+
+    def terminal_states():
+        payload = client.get('/api/downloads/status').get_json()['data']
+        states = {job['id']: job['status'] for job in payload['history']}
+        expected = {
+            first.get_json()['job']['id']: 'completed',
+            cancelled_id: 'cancelled',
+            failed_id: 'failed',
+        }
+        return payload if all(states.get(job_id) == status for job_id, status in expected.items()) else None
+
+    payload = _wait_for(terminal_states)
+    failed_job = next(job for job in payload['history'] if job['id'] == failed_id)
+    assert failed_job['error'] == 'simulierter Fehler'
+    assert calls == ['https://example.test/first', 'https://example.test/fails']
+
+    monkeypatch.setattr(
+        app_module.scraper,
+        'start_download',
+        lambda url, series_path=None, progress_cb=None: True,
+    )
+    retry = client.post(f'/api/downloads/{failed_id}/retry')
+    assert retry.status_code == 202
+
+    def retry_completed():
+        payload = client.get('/api/downloads/status').get_json()['data']
+        retried = next((job for job in payload['history'] if job['id'] == failed_id), None)
+        return retried if retried and retried['status'] == 'completed' else None
+
+    retried = _wait_for(retry_completed)
+    assert retried['progress'] == 100.0
+    assert retried['error'] is None
+
+    with app_module.app.app_context():
+        interrupted = app_module.DownloadJob(
+            url='https://example.test/interrupted',
+            status='downloading',
+            progress=73.0,
+            message='Lief beim Neustart',
+        )
+        app_module.db.session.add(interrupted)
+        app_module.db.session.commit()
+        assert app_module.recover_interrupted_download_jobs() == 1
+        assert interrupted.status == 'pending'
+        assert interrupted.progress == 0.0
+        assert interrupted.started_at is None

--- a/tests/test_scraper_queue_controls.py
+++ b/tests/test_scraper_queue_controls.py
@@ -1,0 +1,90 @@
+import threading
+import time
+
+from scraper import DownloadStatus, StreamScraper
+
+
+def test_download_status_pause_resume_and_cancel() -> None:
+    status = DownloadStatus()
+    status.start_download()
+    assert status.request_pause() is True
+    assert status.get_status()['is_paused'] is True
+
+    released = []
+    waiter = threading.Thread(target=lambda: released.append(status.wait_if_paused()))
+    waiter.start()
+    time.sleep(0.03)
+    assert waiter.is_alive()
+
+    assert status.resume() is True
+    waiter.join(timeout=1.0)
+    assert released == [True]
+
+    assert status.request_pause() is True
+    cancelled = threading.Thread(target=lambda: released.append(status.wait_if_paused()))
+    cancelled.start()
+    time.sleep(0.03)
+    assert status.request_cancel() is True
+    cancelled.join(timeout=1.0)
+    assert released[-1] is False
+
+
+def test_process_series_applies_episode_selection(monkeypatch, tmp_path) -> None:
+    scraper = StreamScraper(download_dir=str(tmp_path))
+    scraper.download_status.start_download()
+    catalog = {
+        'series_name': 'Auswahltest',
+        'url': 'https://example.test/show',
+        'seasons': [
+            {
+                'number': 1,
+                'url': 'https://example.test/show/season-1',
+                'episodes': [
+                    {'number': 1, 'title': 'Eins', 'url': 'https://example.test/e1'},
+                    {'number': 2, 'title': 'Zwei', 'url': 'https://example.test/e2'},
+                ],
+            },
+            {
+                'number': 2,
+                'url': 'https://example.test/show/season-2',
+                'episodes': [
+                    {'number': 1, 'title': 'Drei', 'url': 'https://example.test/e3'},
+                ],
+            },
+        ],
+    }
+    monkeypatch.setattr(scraper, 'get_series_catalog', lambda url, respect_controls=False: catalog)
+
+    processed = []
+
+    def fake_process(url, series_name, season_num, series_path, episodes=None, progress_state=None):
+        processed.append((season_num, [episode['number'] for episode in episodes]))
+        progress_state['completed'] += len(episodes)
+        return True
+
+    monkeypatch.setattr(scraper, '_process_season', fake_process)
+    assert scraper.process_series('https://example.test/show', selection={'1': [2], '2': [1]}) is True
+    assert processed == [(1, [2]), (2, [1])]
+    assert scraper.download_status.get_status()['total_episodes'] == 2
+
+
+def test_process_series_reports_episode_failure(monkeypatch, tmp_path) -> None:
+    scraper = StreamScraper(download_dir=str(tmp_path))
+    scraper.download_status.start_download()
+    catalog = {
+        'series_name': 'Fehlertest',
+        'url': 'https://example.test/show',
+        'seasons': [{
+            'number': 1,
+            'url': 'https://example.test/show/season-1',
+            'episodes': [{'number': 1, 'title': 'Eins', 'url': 'https://example.test/e1'}],
+        }],
+    }
+    monkeypatch.setattr(scraper, 'get_series_catalog', lambda url, respect_controls=False: catalog)
+    monkeypatch.setattr(
+        scraper,
+        '_process_season',
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError('Episode fehlgeschlagen')),
+    )
+
+    assert scraper.process_series('https://example.test/show') is False


### PR DESCRIPTION
## Ergebnis

PR **#6** ist gemergt; dieser PR basiert direkt auf `main` und vervollständigt die geplante persistente Download-Queue.

## Queue und Zustände

- persistentes `DownloadJob`-Modell mit `pending`, `downloading`, `paused`, `completed`, `failed` und `cancelled`
- FIFO-Verarbeitung mehrerer Serienaufträge
- Queue, Auswahl, Fortschritt, Fehler und Verlauf bleiben in SQLite erhalten
- laufende Jobs werden nach einem Neustart erneut eingereiht
- bewusst pausierte Jobs bleiben pausiert und blockieren korrekt nachfolgende Aufträge
- Abbrechen, Wiederholen, Pausieren und Fortsetzen über API und Statusoberfläche
- fehlgeschlagene Episoden setzen den gesamten Auftrag korrekt auf `failed`

## Staffel- und Episodenworkflow

- vor dem Einreihen werden verfügbare Staffeln und Episoden geladen
- Auswahl einzelner Episoden, kompletter Staffeln oder aller Episoden
- Auswahl wird persistent mit dem Queue-Auftrag gespeichert
- getrennte Anzeige für Gesamtfortschritt und Fortschritt der aktuellen Episode
- Anzeige von aktueller Staffel/Episode sowie verarbeitetem Episodenzähler
- sequentielle Staffelverarbeitung für deterministische Auswahl-, Pause- und Fortschrittszustände

Der direkte VOE-Einzeldownload bleibt unverändert.

## Update-Kompatibilität

- fehlende Queue-Spalten aus einer frühen lokalen PR-Vorschau werden beim Start ergänzt
- `SCAP_STREAMS_DB_PATH` ermöglicht isolierte Testdatenbanken; Standard bleibt `streams.db`
- der fest eingebaute Flask-Schlüssel wurde durch einen lokalen Zufallswert beziehungsweise optional `SCAP_SECRET_KEY` ersetzt

## Plan

- [x] persistente Serien-Queue
- [x] Kernzustände und Neustart-Wiederaufnahme
- [x] Fortschritt, Verlauf, Abbrechen und Wiederholen
- [x] Pause und Fortsetzen
- [x] Fortschritt pro Episode
- [x] Staffel-/Episodenauswahl vor dem Download

`ROADMAP.md` enthält denselben abgeschlossenen Stand. Als Nächstes folgen Qualitäts-/Audio-/Untertitelvorschau, Erkennung vorhandener Episoden und Speicherplatzprüfung.

## Prüfung

- **29 Pytest-Tests bestanden**
- Regressionen für FIFO, Auswahlübertragung, Gesamt-/Episodenfortschritt, Pause/Resume, Abbruch, Fehler, Wiederholen und Neustart
- Auswahlfilterung im Scraper und korrekte Fehlerpropagierung getestet
- `node --check static/js/main.js`
- Python-Kompilierungsprüfung für App, Scraper und Tests
- `git diff --check`
- lokaler und veröffentlichter Git-Baum sind identisch
- Remote-Diff gegen `main`: exakt 2 Commits und 9 beabsichtigte Dateien